### PR TITLE
[WOR-315] Automatically tag on push to main branch

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,9 @@
-name: Tag
-on: workflow_dispatch
+name: Bump and tag version
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   tag-job:
@@ -11,7 +15,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.4
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
Rather than rely on a manual dispatch of the tag workflow, we should tag on any merge to main.