### PR TITLE
[WOR-321] Update BPM helmfile after publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,6 @@ jobs:
         run: docker push ${{ steps.image-name.outputs.name }}
 
       - name: Deploy to Terra Dev environment
-        if: github.event_name == 'push' && steps.skiptest.outputs.is-bump == 'no'
         uses: broadinstitute/repository-dispatch@master
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,14 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
 
-      # TODO dispatch notification to terra-helmfile once a chart is setup
+      - name: Deploy to Terra Dev environment
+        if: github.event_name == 'push' && steps.skiptest.outputs.is-bump == 'no'
+        uses: broadinstitute/repository-dispatch@master
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+          repository: broadinstitute/terra-helmfile
+          event-type: update-service
+          client-payload: '{"service": "bpm", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
 
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0


### PR DESCRIPTION
Ticket: [WOR-321](https://broadworkbench.atlassian.net/browse/WOR-321)
* This is most similar to the [Data Catalog `publish.yml` action](https://github.com/DataBiosphere/terra-data-catalog/blob/main/.github/workflows/publish.yml) and will deploy new tags to the dev environment. It seems to me that this job should only run on pushes to the main branch similar to how [WSM does it](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/.github/workflows/tag-publish.yml), but that's a larger change so starting with this for now