### PR TITLE
[WOR-321] trigger publish off successful test runs not new tags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,7 +128,7 @@ jobs:
     if: success() && github.ref == 'refs/heads/main'
 
     steps:
-      - name: Fire off tag action
+      - name: Fire off publish action
         uses: broadinstitute/workflow-dispatch@v1
         with:
           workflow: 'Tag, publish, deploy'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -125,7 +125,7 @@ jobs:
     needs: [ build, jib, unit-tests ]
     runs-on: ubuntu-latest
 
-    if: success() && github.ref == 'refs/heads/main'
+    if: success() && github.ref == 'refs/heads/mtalbott-change-triggers'
 
     steps:
       - name: Fire off tag action

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -125,7 +125,7 @@ jobs:
     needs: [ build, jib, unit-tests ]
     runs-on: ubuntu-latest
 
-    if: success() && github.ref == 'refs/heads/mtalbott-change-triggers'
+    if: success() && github.ref == 'refs/heads/main'
 
     steps:
       - name: Fire off tag action

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,5 +131,5 @@ jobs:
       - name: Fire off tag action
         uses: broadinstitute/workflow-dispatch@v1
         with:
-          workflow: Tag
+          workflow: 'Tag, publish, deploy'
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,6 @@ jobs:
         run: docker push ${{ steps.image-name.outputs.name }}
 
       - name: Deploy to Terra Dev environment
-        if: github.event_name == 'push' && steps.skiptest.outputs.is-bump == 'no'
         uses: broadinstitute/repository-dispatch@master
         with:
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,13 @@ env:
   GOOGLE_PROJECT: broad-dsp-gcr-public
 
 jobs:
+  tag:
+    uses: ./.github/workflows/tag.yml
+
   publish-job:
+    needs: [ tag ]
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/workflows/tag.yml
-        id: tag
-
       - uses: actions/checkout@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v2
@@ -42,7 +43,7 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.new_tag }}
+        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ needs.tag.outputs.new_tag }}
 
       # TODO add google cloud profiler
 
@@ -66,7 +67,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           repository: broadinstitute/terra-helmfile
           event-type: update-service
-          client-payload: '{"service": "bpm", "version": "${{ steps.tag.outputs.new_tag }}", "dev_only": false}'
+          client-payload: '{"service": "bpm", "version": "${{ needs.tag.outputs.new_tag }}", "dev_only": false}'
 
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
-name: Publish and deploy
-on: create
+name: Tag, publish, deploy
+on: workflow_dispatch
+
+# Tags HEAD of main branch, builds and publishes images and deploys to Terra dev environment
 
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
@@ -7,10 +9,11 @@ env:
 
 jobs:
   publish-job:
-    # only publish on new tag
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
+      - uses: ./.github/workflows/tag.yml
+        id: tag
+
       - uses: actions/checkout@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v2
@@ -28,10 +31,6 @@ jobs:
           restore-keys: |
             v1-${{ runner.os }}-gradle-
 
-      - name: Parse tag
-        id: tag
-        run: echo ::set-output name=tag::$(git describe --tags)
-
       # TODO publish client
 
       - name: Auth to GCR
@@ -43,7 +42,7 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
+        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.new_tag }}
 
       # TODO add google cloud profiler
 
@@ -67,7 +66,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           repository: broadinstitute/terra-helmfile
           event-type: update-service
-          client-payload: '{"service": "bpm", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
+          client-payload: '{"service": "bpm", "version": "${{ steps.tag.outputs.new_tag }}", "dev_only": false}'
 
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,14 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
 
-      # TODO dispatch notification to terra-helmfile once a chart is setup
+      - name: Deploy to Terra Dev environment
+        if: github.event_name == 'push' && steps.skiptest.outputs.is-bump == 'no'
+        uses: broadinstitute/repository-dispatch@master
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+          repository: broadinstitute/terra-helmfile
+          event-type: update-service
+          client-payload: '{"service": "bpm", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
 
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,7 +1,7 @@
 name: Tag
 on:
-  - workflow_dispatch
-  - workflow_call:
+  workflow_dispatch
+  workflow_call:
       outputs:
         new_tag:
           description: "Generated tag"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,6 +1,6 @@
 name: Tag
 on:
-  workflow_dispatch
+  workflow_dispatch:
   workflow_call:
       outputs:
         new_tag:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,9 +1,17 @@
 name: Tag
-on: workflow_dispatch
+on:
+  - workflow_dispatch
+  - workflow_call:
+      outputs:
+        new_tag:
+          description: "Generated tag"
+          value: ${{ jobs.tag-job.outputs.new_tag }}
 
 jobs:
   tag-job:
     runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2
@@ -16,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           HOTFIX_BRANCHES: hotfix.*
-          DEFAULT_BUMP: minor
+          DEFAULT_BUMP: patch
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"


### PR DESCRIPTION
ticket: [WOR-321](https://broadworkbench.atlassian.net/browse/WOR-321)
* updates how the publish action is triggered. Note that it can still be run manually, but will no longer run automatically when new tags are created

1. `build-and-test` action is run on merges to `main` branch and when new PRs are opened
2. If `build-and-test` action succeeds AND it was run on a merge to the `main` branch, then the `Tag, deploy, and publish` action (publish.yml) will be dispatched
3. This action first tags the current HEAD of the `main` branch using the tag.yml action
4. Then it goes through the rest of the already established steps to build and push the image as well as deploy the image to the Terra dev environment using the changes found in https://github.com/DataBiosphere/terra-billing-profile-manager/pull/7

* There might still be some work to do to determine if we _need_ a new tag. If a new tag is needed, we will also probably want to provide the option to specify what level of version bump is required.