### PR TITLE
[WOR-321] Fixes to publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   tag:
     uses: ./.github/workflows/tag.yml
+    with:
+      token: ${{ secrets.BROADBOT_TOKEN }}
 
   publish-job:
     needs: [ tag ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   tag:
     uses: ./.github/workflows/tag.yml
+    with:
+      secrets: inherit
 
   publish-job:
     needs: [ tag ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,7 @@ env:
 jobs:
   tag:
     uses: ./.github/workflows/tag.yml
-    with:
-      secrets: inherit
+    secrets: inherit
 
   publish-job:
     needs: [ tag ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,6 @@ env:
 jobs:
   tag:
     uses: ./.github/workflows/tag.yml
-    with:
-      token: ${{ secrets.BROADBOT_TOKEN }}
 
   publish-job:
     needs: [ tag ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ needs.tag.outputs.new_tag }}
+        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ needs.tag.outputs.tag }}
 
       # TODO add google cloud profiler
 
@@ -68,7 +68,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           repository: broadinstitute/terra-helmfile
           event-type: update-service
-          client-payload: '{"service": "bpm", "version": "${{ needs.tag.outputs.new_tag }}", "dev_only": false}'
+          client-payload: '{"service": "bpm", "version": "${{ needs.tag.outputs.tag }}", "dev_only": false}'
 
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.4
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,10 +2,13 @@ name: Tag
 on:
   workflow_dispatch:
   workflow_call:
-      outputs:
-        new_tag:
-          description: "Generated tag"
-          value: ${{ jobs.tag-job.outputs.new_tag }}
+    secrets:
+      BROADBOT_TOKEN:
+        required: true
+    outputs:
+      new_tag:
+        description: "Generated tag"
+        value: ${{ jobs.tag-job.outputs.new_tag }}
 
 jobs:
   tag-job:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,9 +2,6 @@ name: Tag
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      BROADBOT_TOKEN:
-        required: true
     outputs:
       new_tag:
         description: "Generated tag"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,15 +3,15 @@ on:
   workflow_dispatch:
   workflow_call:
     outputs:
-      new_tag:
+      tag:
         description: "Generated tag"
-        value: ${{ jobs.tag-job.outputs.new_tag }}
+        value: ${{ jobs.tag-job.outputs.tag }}
 
 jobs:
   tag-job:
     runs-on: ubuntu-latest
     outputs:
-      new_tag: ${{ steps.tag.outputs.new_tag }}
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,7 +2,6 @@ name: Tag
 on:
   workflow_dispatch:
   workflow_call:
-    secrets: inherit
     outputs:
       new_tag:
         description: "Generated tag"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,6 +2,7 @@ name: Tag
 on:
   workflow_dispatch:
   workflow_call:
+    secrets: inherit
     outputs:
       new_tag:
         description: "Generated tag"


### PR DESCRIPTION
Ticket: [WOR-321](https://broadworkbench.atlassian.net/browse/WOR-321)

**Fixes to publish and tag workflows**
* secrets weren't getting passed properly from publish.yml to tag.yml. adding `secrets: inherit` solved this problem
* there was an issue where the `bumper` action wasn't bumping the new version and there was no tag output which lead to failures in publish.yml. Bumping the `bumper` version to the most recent version fixed this.
* I changed `new_tag` to `tag` when trying to figure out why publish.yml couldn't find the tag properly. This probably wasn't necessary, but I like it more as we may not always have a _new_ tag, so `tag` seems slightly better and I'm leaving this change in
