### PR TITLE
[WOR-319] Publish API client

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
             v1-${{ runner.os }}-gradle-
 
       - name: Publish API client
-        run: ./gradlew --build-cache :client-resttemplate:artifactoryPublish
+        run: ./gradlew --build-cache :client:artifactoryPublish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,12 @@ jobs:
           restore-keys: |
             v1-${{ runner.os }}-gradle-
 
-      # TODO publish client
+      - name: Publish API client
+        run: ./gradlew --build-cache :client-resttemplate:artifactoryPublish
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ARTIFACTORY_REPO_KEY: libs-snapshot-local
 
       - name: Auth to GCR
         uses: google-github-actions/auth@v0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
             v1-${{ runner.os }}-gradle-
 
       - name: Publish API client
-        run: ./gradlew --build-cache :client:artifactoryPublish
+        run: ./gradlew :client:artifactoryPublish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -46,8 +46,6 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.hamcrest:hamcrest:2.2'
-
-    implementation 'bio.terra:terra-common-lib:0.0.53-SNAPSHOT'
 }
 
 // https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement

--- a/client/artifactory.gradle
+++ b/client/artifactory.gradle
@@ -17,7 +17,7 @@ java {
 
 publishing {
     publications {
-        catalogClientLibrary(MavenPublication) {
+        billingProfileManagerClientLibrary(MavenPublication) {
             artifactId = "billing-profile-manager-client"
             from components.java
             versionMapping {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -10,7 +10,8 @@ apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
 
 dependencies {
-	implementation 'bio.terra:terra-common-lib'
+	implementation 'bio.terra:terra-common-lib:0.0.53-SNAPSHOT'
+
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'


### PR DESCRIPTION
## Context
We want to publish the BPM client for consumption by rawls and others

## This PR
* Wires up the publish github action to publish the JAR to the [broad artifactory instance](http://broadinstitute.jfrog.io)
* Removes the terra-common-library as a global dependency that'll get included in any subproject (including the client subproject). This dependency was causing the pom generated during the publish step to include stairway and several other unwanted dependencies, which was causing issues downstream during testing in rawls. It is still being included as a dependency on the `service` project. 

## Testing
* Published a snapshot version of the BPM client via the publish action to artifactory
* Pulled in the client JAR in a local Rawls. Verified that it can build and make calls to the dev BPM instance and get a 200 result

