### PR TITLE
[WOR-431] Include resource group name in managed apps response

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -47,8 +47,7 @@ public class AzureService {
                     .applicationDeploymentName(app.name())
                     .subscriptionId(subscriptionId)
                     .managedResourceGroupId(
-                        normalizeManagedResourceGroupId(app.managedResourceGroupId())
-                    )
+                        normalizeManagedResourceGroupId(app.managedResourceGroupId()))
                     .resourceGroupName(resourceGroupNameFromApp(app.id()))
                     .tenantId(tenantId))
         .toList();

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -47,7 +47,9 @@ public class AzureService {
                     .applicationDeploymentName(app.name())
                     .subscriptionId(subscriptionId)
                     .managedResourceGroupId(
-                        normalizeManagedResourceGroupId(app.managedResourceGroupId()))
+                        normalizeManagedResourceGroupId(app.managedResourceGroupId())
+                    )
+                    .resourceGroupName(resourceGroupNameFromApp(app.id()))
                     .tenantId(tenantId))
         .toList();
   }
@@ -55,6 +57,14 @@ public class AzureService {
   private String normalizeManagedResourceGroupId(String mrgId) {
     var tokens = mrgId.split("/");
     return tokens[tokens.length - 1];
+  }
+
+  private String resourceGroupNameFromApp(String appId) {
+    var tokens = appId.split("/");
+    if (tokens.length < 5) {
+      throw new InvalidAzureResourceGroupNameException("Unable to parse resource group name");
+    }
+    return tokens[4];
   }
 
   private boolean isAuthedTerraManagedApp(AuthenticatedUserRequest userRequest, Application app) {

--- a/service/src/main/java/bio/terra/profile/service/azure/InvalidAzureResourceGroupNameException.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/InvalidAzureResourceGroupNameException.java
@@ -1,0 +1,9 @@
+package bio.terra.profile.service.azure;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class InvalidAzureResourceGroupNameException extends InternalServerErrorException {
+    public InvalidAzureResourceGroupNameException(String message) {
+      super(message);
+    }
+}

--- a/service/src/main/java/bio/terra/profile/service/azure/InvalidAzureResourceGroupNameException.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/InvalidAzureResourceGroupNameException.java
@@ -3,7 +3,7 @@ package bio.terra.profile.service.azure;
 import bio.terra.common.exception.InternalServerErrorException;
 
 public class InvalidAzureResourceGroupNameException extends InternalServerErrorException {
-    public InvalidAzureResourceGroupNameException(String message) {
-      super(message);
-    }
+  public InvalidAzureResourceGroupNameException(String message) {
+    super(message);
+  }
 }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -304,7 +304,10 @@ components:
         - managedResourceGroupId
         - subscriptionId
         - tenantId
+        - resourceGroupName
       properties:
+        resourceGroupName:
+          type: string
         applicationDeploymentName:
           type: string
           description: Name of the Azure application deployment

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -79,8 +79,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
                 .tenantId(tenantId)
                 .managedResourceGroupId("mrg_fake1")
                 .subscriptionId(subId)
-                .resourceGroupName("123")
-        );
+                .resourceGroupName("123"));
     assertEquals(result, expected);
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -39,6 +39,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
                 "authorizedTerraUser",
                 Map.of("value", String.format("%s,other@example.com", authedUserEmail))));
     when(authedTerraApp.managedResourceGroupId()).thenReturn("mrg_fake1");
+    when(authedTerraApp.id()).thenReturn("fake/azure/api/abc/123");
     when(authedTerraApp.name()).thenReturn("fake_app_1");
 
     var unauthedTerraApp = mock(Application.class);
@@ -46,11 +47,14 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     when(unauthedTerraApp.parameters())
         .thenReturn(Map.of("authorizedTerraUser", Map.of("value", "other@example.com")));
     when(unauthedTerraApp.managedResourceGroupId()).thenReturn("mrg_fake2");
+    when(unauthedTerraApp.id()).thenReturn("fake/azure/api/abc/123");
+
     when(unauthedTerraApp.name()).thenReturn("fake_app_2");
 
     var otherNonTerraApp = mock(Application.class);
     when(otherNonTerraApp.plan()).thenReturn(new Plan().withProduct("other_offer"));
     when(otherNonTerraApp.managedResourceGroupId()).thenReturn("mrg_fake3");
+    when(otherNonTerraApp.id()).thenReturn("fake/azure/api/abc/123");
     when(otherNonTerraApp.name()).thenReturn("fake_app_3");
 
     var appsList = Stream.of(authedTerraApp, unauthedTerraApp, otherNonTerraApp);
@@ -74,7 +78,9 @@ public class AzureServiceUnitTest extends BaseUnitTest {
                 .applicationDeploymentName("fake_app_1")
                 .tenantId(tenantId)
                 .managedResourceGroupId("mrg_fake1")
-                .subscriptionId(subId));
+                .subscriptionId(subId)
+                .resourceGroupName("123")
+        );
     assertEquals(result, expected);
   }
 }


### PR DESCRIPTION
We need the application resource group name when creating an azure spend profile. As such, the managed apps enumeration endpoint needs to parse the app ID and return the relevant field from the azure apps listing response. 