### PR TITLE
[WOR-431] Adjust azure profile data model managed app coordinates

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -33,7 +33,8 @@ public class AzureApiController implements AzureApi {
   public ResponseEntity<AzureManagedAppsResponseModel> getManagedAppDeployments(
       UUID azureSubscriptionId) {
     final AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
-    var managedApps = this.azureService.getManagedAppDeployments(azureSubscriptionId, userRequest);
+    var managedApps =
+        this.azureService.getAuthorizedManagedAppDeployments(azureSubscriptionId, userRequest);
 
     return new ResponseEntity<>(
         new AzureManagedAppsResponseModel().managedApps(managedApps), HttpStatus.OK);

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -29,7 +29,7 @@ public class ProfileDao {
   // SQL select string constants
   private static final String SQL_SELECT_LIST =
       "id, display_name, biller, billing_account_id, description, cloud_platform, "
-          + "tenant_id, subscription_id, resource_group_name, application_deployment_name, "
+          + "tenant_id, subscription_id, managed_resource_group_id, "
           + "created_date, created_by, last_modified";
 
   private static final String SQL_GET =
@@ -53,15 +53,14 @@ public class ProfileDao {
     String sql =
         "INSERT INTO billing_profile"
             + " (id, display_name, biller, billing_account_id, description, cloud_platform, "
-            + "     tenant_id, subscription_id, resource_group_name, application_deployment_name, created_by) VALUES "
+            + "     tenant_id, subscription_id, managed_resource_group_id, created_by) VALUES "
             + " (:id, :display_name, :biller, :billing_account_id, :description, :cloud_platform, "
-            + "     :tenant_id, :subscription_id, :resource_group_name, :application_deployment_name, :created_by)";
+            + "     :tenant_id, :subscription_id, :managed_resource_group_id, :created_by)";
 
     String billingAccountId = profile.billingAccountId().orElse(null);
     UUID tenantId = profile.tenantId().orElse(null);
     UUID subscriptionId = profile.subscriptionId().orElse(null);
-    String resourceGroupName = profile.resourceGroupName().orElse(null);
-    String applicationDeploymentName = profile.applicationDeploymentName().orElse(null);
+    String managedResourceGroupId = profile.managedResourceGroupId().orElse(null);
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -73,8 +72,7 @@ public class ProfileDao {
             .addValue("cloud_platform", profile.cloudPlatform().name())
             .addValue("tenant_id", tenantId)
             .addValue("subscription_id", subscriptionId)
-            .addValue("resource_group_name", resourceGroupName)
-            .addValue("application_deployment_name", applicationDeploymentName)
+            .addValue("managed_resource_group_id", managedResourceGroupId)
             .addValue("created_by", user.getEmail());
 
     var keyHolder = new DaoKeyHolder();
@@ -89,8 +87,7 @@ public class ProfileDao {
         profile.billingAccountId(),
         profile.tenantId(),
         profile.subscriptionId(),
-        profile.resourceGroupName(),
-        profile.applicationDeploymentName(),
+        profile.managedResourceGroupId(),
         keyHolder.getInstant("created_date"),
         keyHolder.getInstant("last_modified"),
         keyHolder.getString("created_by"));
@@ -148,8 +145,7 @@ public class ProfileDao {
           Optional.ofNullable(rs.getString("billing_account_id")),
           Optional.ofNullable(rs.getObject("tenant_id", UUID.class)),
           Optional.ofNullable(rs.getObject("subscription_id", UUID.class)),
-          Optional.ofNullable(rs.getString("resource_group_name")),
-          Optional.ofNullable(rs.getString("application_deployment_name")),
+          Optional.ofNullable(rs.getString("managed_resource_group_id")),
           rs.getTimestamp("created_date").toInstant(),
           rs.getTimestamp("last_modified").toInstant(),
           rs.getString("created_by"));

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -33,7 +33,7 @@ public class AzureService {
    * @param userRequest Authorized user request
    * @return List of Terra Azure managed applications the user has access to
    */
-  public List<AzureManagedAppModel> getManagedAppDeployments(
+  public List<AzureManagedAppModel> getAuthorizedManagedAppDeployments(
       UUID subscriptionId, AuthenticatedUserRequest userRequest) {
     var tenantId = appService.getTenantForSubscription(subscriptionId);
 
@@ -49,6 +49,7 @@ public class AzureService {
                     .managedResourceGroupId(
                         normalizeManagedResourceGroupId(app.managedResourceGroupId()))
                     .tenantId(tenantId))
+        .distinct()
         .toList();
   }
 

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
@@ -2,6 +2,7 @@ package bio.terra.profile.service.profile.flight.create;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
+import bio.terra.profile.service.azure.AzureService;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.job.JobMapKeys;
@@ -19,6 +20,7 @@ public class CreateProfileFlight extends Flight {
     ProfileDao profileDao = appContext.getBean(ProfileDao.class);
     CrlService crlService = appContext.getBean(CrlService.class);
     SamService samService = appContext.getBean(SamService.class);
+    AzureService azureService = appContext.getBean(AzureService.class);
 
     BillingProfile profile =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BillingProfile.class);
@@ -32,7 +34,7 @@ public class CreateProfileFlight extends Flight {
         addStep(new CreateProfileVerifyAccountStep(crlService, profile, user));
         break;
       case AZURE:
-        addStep(new CreateProfileVerifyDeployedApplicationStep(crlService, profile, user));
+        addStep(new CreateProfileVerifyDeployedApplicationStep(azureService, profile, user));
         break;
     }
     addStep(new CreateProfileAuthzIamStep(samService, profile, user));

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -21,7 +21,7 @@ record CreateProfileVerifyDeployedApplicationStep(
     try {
       var apps =
           azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user);
-      var matchingApps =
+      canAccess =
           apps.stream()
               .filter(
                   app ->
@@ -29,8 +29,7 @@ record CreateProfileVerifyDeployedApplicationStep(
                               app.getManagedResourceGroupId(),
                               profile.managedResourceGroupId().get())
                           && app.getSubscriptionId() == profile.subscriptionId().get())
-              .toList();
-      canAccess = matchingApps.size() == 1;
+                  .count() == 1;
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -1,44 +1,36 @@
 package bio.terra.profile.service.profile.flight.create;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.service.crl.CrlService;
+import bio.terra.profile.service.azure.AzureService;
 import bio.terra.profile.service.profile.exception.InaccessibleApplicationDeploymentException;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import java.util.Map;
-import java.util.UUID;
+import java.util.Objects;
 
 /** Step to verify the user has access to an Azure profile's managed resource group. */
 record CreateProfileVerifyDeployedApplicationStep(
-    CrlService crlService, BillingProfile profile, AuthenticatedUserRequest user) implements Step {
-
-  private static final String DEPLOYED_APPLICATION_RESOURCE_ID =
-      "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Solutions/applications/%s";
+    AzureService azureService, BillingProfile profile, AuthenticatedUserRequest user)
+    implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) {
-    final String applicationResourceId =
-        getApplicationDeploymentId(
-            profile.subscriptionId().get(),
-            profile.resourceGroupName().get(),
-            profile.applicationDeploymentName().get());
-
     final boolean canAccess;
     try {
-      var resourceManager =
-          crlService.getResourceManager(profile.tenantId().get(), profile.subscriptionId().get());
-      var applicationDeployment = resourceManager.genericResources().getById(applicationResourceId);
-      var properties =
-          (Map<String, Map<String, Map<String, String>>>) applicationDeployment.properties();
-      canAccess =
-          properties
-              .get("parameters")
-              .get("authorizedTerraUser")
-              .get("value")
-              .equalsIgnoreCase(user.getEmail());
+      var apps =
+          azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user);
+      var matchingApps =
+          apps.stream()
+              .filter(
+                  app ->
+                      Objects.equals(
+                              app.getManagedResourceGroupId(),
+                              profile.managedResourceGroupId().get())
+                          && app.getSubscriptionId() == profile.subscriptionId().get())
+              .toList();
+      canAccess = matchingApps.size() == 1;
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
@@ -47,7 +39,7 @@ record CreateProfileVerifyDeployedApplicationStep(
       throw new InaccessibleApplicationDeploymentException(
           String.format(
               "The user [%s] needs access to deployed application [%s] to perform the requested operation",
-              user.getEmail(), applicationResourceId));
+              user.getEmail(), profile.managedResourceGroupId().get()));
     }
 
     return StepResult.getStepResultSuccess();
@@ -57,23 +49,5 @@ record CreateProfileVerifyDeployedApplicationStep(
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     // Verify account has no side effects to clean up
     return StepResult.getStepResultSuccess();
-  }
-
-  /**
-   * Return the Azure resource ID for the application deployment associated with the specified
-   * parameters.
-   *
-   * @param subscriptionId The ID of the subscription into which the application is deployed
-   * @param resourceGroupName The name of the resource group into which the application is deployed
-   * @param applicationDeploymentName The name of the application deployment
-   * @return Azure resource identifier
-   */
-  private static String getApplicationDeploymentId(
-      UUID subscriptionId, String resourceGroupName, String applicationDeploymentName) {
-    return String.format(
-        DEPLOYED_APPLICATION_RESOURCE_ID,
-        subscriptionId,
-        resourceGroupName,
-        applicationDeploymentName);
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -23,13 +23,14 @@ record CreateProfileVerifyDeployedApplicationStep(
           azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user);
       canAccess =
           apps.stream()
-              .filter(
-                  app ->
-                      Objects.equals(
-                              app.getManagedResourceGroupId(),
-                              profile.managedResourceGroupId().get())
-                          && app.getSubscriptionId() == profile.subscriptionId().get())
-                  .count() == 1;
+                  .filter(
+                      app ->
+                          Objects.equals(
+                                  app.getManagedResourceGroupId(),
+                                  profile.managedResourceGroupId().get())
+                              && app.getSubscriptionId() == profile.subscriptionId().get())
+                  .count()
+              == 1;
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }

--- a/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
@@ -18,8 +18,7 @@ public record BillingProfile(
     Optional<String> billingAccountId,
     Optional<UUID> tenantId,
     Optional<UUID> subscriptionId,
-    Optional<String> resourceGroupName,
-    Optional<String> applicationDeploymentName,
+    Optional<String> managedResourceGroupId,
     Instant createdTime,
     Instant lastModified,
     String createdBy) {
@@ -47,17 +46,15 @@ public record BillingProfile(
       }
       if (request.getTenantId() != null
           || request.getSubscriptionId() != null
-          || request.getResourceGroupName() != null
-          || request.getApplicationDeploymentName() != null) {
+          || request.getManagedResourceGroupId() != null) {
         throw new MissingRequiredFieldsException("GCP billing profile must not contain Azure data");
       }
     } else if (request.getCloudPlatform().equals(CloudPlatform.AZURE)) {
       if (request.getTenantId() == null
           || request.getSubscriptionId() == null
-          || request.getResourceGroupName() == null
-          || request.getApplicationDeploymentName() == null) {
+          || request.getManagedResourceGroupId() == null) {
         throw new MissingRequiredFieldsException(
-            "Azure billing profile requires tenantId, subscriptionId, resourceGroupName, and applicationDeploymentName");
+            "Azure billing profile requires tenantId, subscriptionId, managedResourceGroupId");
       }
       if (request.getBillingAccountId() != null) {
         throw new MissingRequiredFieldsException("Azure billing profile must not contain GCP data");
@@ -73,8 +70,7 @@ public record BillingProfile(
         Optional.ofNullable(request.getBillingAccountId()),
         Optional.ofNullable(request.getTenantId()),
         Optional.ofNullable(request.getSubscriptionId()),
-        Optional.ofNullable(request.getResourceGroupName()),
-        Optional.ofNullable(request.getApplicationDeploymentName()),
+        Optional.ofNullable(request.getManagedResourceGroupId()),
         null,
         null,
         null);
@@ -95,8 +91,7 @@ public record BillingProfile(
         .billingAccountId(billingAccountId.orElse(null))
         .tenantId(tenantId.orElse(null))
         .subscriptionId(subscriptionId.orElse(null))
-        .resourceGroupName(resourceGroupName.orElse(null))
-        .applicationDeploymentName(applicationDeploymentName.orElse(null))
+        .managedResourceGroupId(managedResourceGroupId.orElse(null))
         .createdDate(createdTime.toString())
         .lastModified(lastModified.toString())
         .createdBy(createdBy);

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -250,12 +250,9 @@ components:
           type: string
           description: Unique identifier of the Azure subscription
           format: uuid
-        resourceGroupName:
+        managedResourceGroupId:
           type: string
-          description: Name of the Azure resource group
-        applicationDeploymentName:
-          type: string
-          description: Name of the Azure application deployment
+          description: ID of the Azure managed resource group
 
     UpdateProfileRequest:
       type: object
@@ -353,12 +350,9 @@ components:
           type: string
           description: Unique identifier of the Azure subscription
           format: uuid
-        resourceGroupName:
+        managedResourceGroupId:
           type: string
-          description: Name of the Azure resource group
-        applicationDeploymentName:
-          type: string
-          description: Name of the Azure application deployment
+          description: Managed resource group ID of the Terra deployment
         createdDate:
           type: string
           description: Date the profile was created

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -252,7 +252,7 @@ components:
           format: uuid
         managedResourceGroupId:
           type: string
-          description: ID of the Azure managed resource group
+          description: ID of the Azure managed resource group, of the form mrg-terra-integration-test-20211118
 
     UpdateProfileRequest:
       type: object

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -13,4 +13,5 @@
 
     <include file="changesets/20220117_billing_profiles.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220713_billing_profiles_last_modified.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220803_billing_profiles_managed_resource_group_id.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20220803_billing_profiles_managed_resource_group_id.yaml
+++ b/service/src/main/resources/db/changesets/20220803_billing_profiles_managed_resource_group_id.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: billing_profile_managed_app_coords
+      author: aherbst
+      changes:
+        - addColumn:
+            tableName: billing_profile
+            columns:
+              - column:
+                  name: managed_resource_group_id
+                  type: text
+                  constraints:
+                    nullable: true
+                  remarks: |
+                    Azure Managed Resource Group ID for the Terra deployment
+        - dropColumn:
+            tableName: billing_profile
+            columns:
+              - column:
+                  name: resource_group_name
+              - column:
+                  name: application_deployment_name
+

--- a/service/src/test/java/bio/terra/profile/common/BaseSpringUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/common/BaseSpringUnitTest.java
@@ -1,0 +1,18 @@
+package bio.terra.profile.common;
+
+import bio.terra.profile.app.Main;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Base class for unit tests requiring Spring functionality (autowiring, etc.)
+ */
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+public class BaseSpringUnitTest extends BaseUnitTest {}

--- a/service/src/test/java/bio/terra/profile/common/BaseSpringUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/common/BaseSpringUnitTest.java
@@ -1,17 +1,12 @@
 package bio.terra.profile.common;
 
 import bio.terra.profile.app.Main;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-/**
- * Base class for unit tests requiring Spring functionality (autowiring, etc.)
- */
-
+/** Base class for unit tests requiring Spring functionality (autowiring, etc.) */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = Main.class)
 @SpringBootTest

--- a/service/src/test/java/bio/terra/profile/common/BaseUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/common/BaseUnitTest.java
@@ -1,16 +1,8 @@
 package bio.terra.profile.common;
 
-import bio.terra.profile.app.Main;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Tag("unit")
 @ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
-public class BaseUnitTest {}
+public class BaseUnitTest { }

--- a/service/src/test/java/bio/terra/profile/common/BaseUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/common/BaseUnitTest.java
@@ -5,4 +5,4 @@ import org.springframework.test.context.ActiveProfiles;
 
 @Tag("unit")
 @ActiveProfiles({"test", "unit"})
-public class BaseUnitTest { }
+public class BaseUnitTest {}

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
-import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.model.AzureManagedAppModel;
 import com.azure.resourcemanager.managedapplications.models.Application;

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.model.AzureManagedAppModel;
 import com.azure.resourcemanager.managedapplications.models.Application;
@@ -66,7 +67,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     var azureService =
         new AzureService(appService, new AzureConfiguration("fake", "fake", "fake", offers));
 
-    var result = azureService.getManagedAppDeployments(subId, user);
+    var result = azureService.getAuthorizedManagedAppDeployments(subId, user);
 
     var expected =
         List.of(
@@ -76,5 +77,44 @@ public class AzureServiceUnitTest extends BaseUnitTest {
                 .managedResourceGroupId("mrg_fake1")
                 .subscriptionId(subId));
     assertEquals(result, expected);
+  }
+
+  @Test
+  public void getManagedApps_dedupesApps() {
+    var subId = UUID.randomUUID();
+    var authedUserEmail = "profile@example.com";
+    var user =
+        AuthenticatedUserRequest.builder()
+            .setSubjectId("12345")
+            .setEmail(authedUserEmail)
+            .setToken("token")
+            .build();
+    var offerName = "known_terra_offer";
+
+    var authedTerraApp = mock(Application.class);
+    when(authedTerraApp.plan()).thenReturn(new Plan().withProduct(offerName));
+    when(authedTerraApp.parameters())
+        .thenReturn(
+            Map.of(
+                "authorizedTerraUser",
+                Map.of("value", String.format("%s,other@example.com", authedUserEmail))));
+    when(authedTerraApp.managedResourceGroupId()).thenReturn("mrg_fake1");
+    when(authedTerraApp.name()).thenReturn("fake_app_1");
+    var appsList = Stream.of(authedTerraApp, authedTerraApp);
+    var appService = mock(ApplicationService.class);
+    var tenantId = UUID.randomUUID();
+    when(appService.getApplicationsForSubscription(eq(subId))).thenReturn(appsList);
+    when(appService.getTenantForSubscription(subId)).thenReturn(tenantId);
+
+    var offer = new AzureConfiguration.AzureApplicationOffer();
+    offer.setName("FAKE_APP_NAME");
+    offer.setAuthorizedUserKey("authorizedTerraUser");
+    var offers = Map.of(offerName, offer);
+    var azureService =
+        new AzureService(appService, new AzureConfiguration("fake", "fake", "fake", offers));
+
+    var result = azureService.getAuthorizedManagedAppDeployments(subId, user);
+
+    assertEquals(result.size(), 1, "Duplicate app instances should be removed");
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.profile.exception.ProfileNotFoundException;
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 
-public class ProfileDaoTest extends BaseUnitTest {
+public class ProfileDaoTest extends BaseSpringUnitTest {
   @Autowired private ProfileDao profileDao;
   private AuthenticatedUserRequest user;
   private List<UUID> profileIds;
@@ -133,7 +133,6 @@ public class ProfileDaoTest extends BaseUnitTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty(),
         null,
         null,
         null);
@@ -149,8 +148,7 @@ public class ProfileDaoTest extends BaseUnitTest {
     assertEquals(expected.billingAccountId(), actual.billingAccountId());
     assertEquals(expected.tenantId(), actual.tenantId());
     assertEquals(expected.subscriptionId(), actual.subscriptionId());
-    assertEquals(expected.resourceGroupName(), actual.resourceGroupName());
-    assertEquals(expected.applicationDeploymentName(), actual.applicationDeploymentName());
+    assertEquals(expected.managedResourceGroupId(), actual.managedResourceGroupId());
     assertNotNull(actual.createdTime());
     assertNotNull(actual.lastModified());
     assertEquals(user.getEmail(), actual.createdBy());

--- a/service/src/test/java/bio/terra/profile/service/iam/SamAuthenticatedUserRequestFactoryTest.java
+++ b/service/src/test/java/bio/terra/profile/service/iam/SamAuthenticatedUserRequestFactoryTest.java
@@ -7,14 +7,14 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-public class SamAuthenticatedUserRequestFactoryTest extends BaseUnitTest {
+public class SamAuthenticatedUserRequestFactoryTest extends BaseSpringUnitTest {
   private static final String EMAIL = "billing@unit.com";
   private static final String SUBJECT = "12345";
   private static final String TOKEN = "not-a-real-token";

--- a/service/src/test/java/bio/terra/profile/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/service/job/JobServiceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.model.JobReport;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.job.exception.InvalidJobIdException;
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
-class JobServiceTest extends BaseUnitTest {
+class JobServiceTest extends BaseSpringUnitTest {
   private final AuthenticatedUserRequest testUser =
       AuthenticatedUserRequest.builder()
           .setSubjectId("StairwayUnit")

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.iam.SamService;
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class ProfileServiceUnitTest extends BaseUnitTest {
+public class ProfileServiceUnitTest extends BaseSpringUnitTest {
 
   @Mock private ProfileDao profileDao;
   @Mock private SamService samService;
@@ -62,7 +62,6 @@ public class ProfileServiceUnitTest extends BaseUnitTest {
             "direct",
             CloudPlatform.GCP,
             Optional.of("billingAccount"),
-            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStepTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.google.billing.CloudBillingClientCow;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.InaccessibleBillingAccountException;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-public class CreateProfileVerifyAccountStepTest extends BaseUnitTest {
+public class CreateProfileVerifyAccountStepTest extends BaseSpringUnitTest {
 
   @Mock private FlightContext flightContext;
   @Mock private CrlService crlService;
@@ -51,7 +51,6 @@ public class CreateProfileVerifyAccountStepTest extends BaseUnitTest {
             "direct",
             CloudPlatform.GCP,
             Optional.of("billingAccount"),
-            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
@@ -60,11 +60,12 @@ public class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUn
   @Test
   public void verifyManagedApp() {
     when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user))
-            .thenReturn(List.of(
-                    new AzureManagedAppModel()
-                            .subscriptionId(profile.subscriptionId().get())
-                            .tenantId(profile.tenantId().get())
-                            .managedResourceGroupId(profile.managedResourceGroupId().get())));
+        .thenReturn(
+            List.of(
+                new AzureManagedAppModel()
+                    .subscriptionId(profile.subscriptionId().get())
+                    .tenantId(profile.tenantId().get())
+                    .managedResourceGroupId(profile.managedResourceGroupId().get())));
     var result = step.doStep(flightContext);
 
     assertEquals(StepResult.getStepResultSuccess(), result);

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
@@ -2,9 +2,11 @@ package bio.terra.profile.service.profile.flight.create;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.common.BaseSpringUnitTest;
+import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.azure.AzureService;
 import bio.terra.profile.service.profile.exception.InaccessibleApplicationDeploymentException;
@@ -12,6 +14,7 @@ import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +59,12 @@ public class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUn
 
   @Test
   public void verifyManagedApp() {
-
+    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user))
+            .thenReturn(List.of(
+                    new AzureManagedAppModel()
+                            .subscriptionId(profile.subscriptionId().get())
+                            .tenantId(profile.tenantId().get())
+                            .managedResourceGroupId(profile.managedResourceGroupId().get())));
     var result = step.doStep(flightContext);
 
     assertEquals(StepResult.getStepResultSuccess(), result);

--- a/service/src/test/java/bio/terra/profile/service/status/BaseStatusServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/service/status/BaseStatusServiceTest.java
@@ -3,13 +3,13 @@ package bio.terra.profile.service.status;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.profile.app.configuration.StatusCheckConfiguration;
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.model.SystemStatus;
 import bio.terra.profile.model.SystemStatusSystems;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
-public class BaseStatusServiceTest extends BaseUnitTest {
+public class BaseStatusServiceTest extends BaseSpringUnitTest {
   private static final int STALENESS = 7;
   private static final StatusCheckConfiguration configuration =
       new StatusCheckConfiguration(true, 5, 1, STALENESS);

--- a/service/src/test/java/bio/terra/profile/service/status/ProfileStatusServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/service/status/ProfileStatusServiceTest.java
@@ -3,7 +3,7 @@ package bio.terra.profile.service.status;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 
-import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.model.SystemStatus;
 import bio.terra.profile.model.SystemStatusSystems;
 import bio.terra.profile.service.iam.SamService;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class ProfileStatusServiceTest extends BaseUnitTest {
+public class ProfileStatusServiceTest extends BaseSpringUnitTest {
   @Autowired private ProfileStatusService statusService;
 
   @MockBean private SamService mockSamService;


### PR DESCRIPTION
## Context
There are a couple of problems with the current create profile code path with respect to Azure. 
It pulls the app down for access control checks by using the application deployment name and the parent resource group name. This is problematic because we:
1. Should be using the same code path for access control checks when enumerating managed apps via the /managedApps endpoint as we are when creating a profile
2. We need the managed resource group ID to be persisted with the profile so we can provide that to WSM downstream when creating workspace resources.

## This PR
* Refactors the data model to swap out `applicationDeploymentName` + `resourceGroupName` for `managedResourceGroupId`
* Changes the profile creation logic to reuse the managed application enumeration codepath in `AzureService` as the `/managedApps` endpoint uses
* Introduces a `BaseUnitTest` base class for use when testing POJOs. In my testing, it was becoming quite cumbersome/slow to spin up spring boot tests for basic business logic tests.