### PR TITLE
Reworking well-known offers

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
@@ -2,7 +2,7 @@ package bio.terra.profile.app.configuration;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
-import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,7 +12,7 @@ public record AzureConfiguration(
     String managedAppClientId,
     String managedAppClientSecret,
     String managedAppTenantId,
-    Map<String, AzureApplicationOffer> applicationOffers) {
+    Set<AzureApplicationOffer> applicationOffers) {
   private static final Logger logger = LoggerFactory.getLogger(AzureConfiguration.class);
 
   /**
@@ -63,13 +63,13 @@ public record AzureConfiguration(
    * Well-known Microsoft Marketplace offers; only deployments of these offers will be allowed to
    * have billing profiles created against them
    */
-  public Map<String, AzureApplicationOffer> getApplicationOffers() {
+  public Set<AzureApplicationOffer> getApplicationOffers() {
     return applicationOffers;
   }
 
   public void logOffers() {
-    for (String offer : this.applicationOffers.keySet()) {
-      logger.info("Azure application offer {}", offer);
+    for (AzureApplicationOffer offer : this.applicationOffers()) {
+      logger.info("Azure application offer {}", offer.name);
     }
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -89,7 +89,7 @@ profile:
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
 
     application-offers:
-      fake-terra-app:
+      - name: terra-workspace-dev
         authorized-user-key: authorizedTerraUser
 
 

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -13,6 +13,7 @@ import com.azure.resourcemanager.managedapplications.models.Application;
 import com.azure.resourcemanager.managedapplications.models.Plan;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -60,9 +61,9 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     when(appService.getTenantForSubscription(subId)).thenReturn(tenantId);
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
-    offer.setName("FAKE_APP_NAME");
+    offer.setName(offerName);
     offer.setAuthorizedUserKey("authorizedTerraUser");
-    var offers = Map.of(offerName, offer);
+    var offers = Set.of(offer);
     var azureService =
         new AzureService(appService, new AzureConfiguration("fake", "fake", "fake", offers));
 
@@ -106,9 +107,9 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     when(appService.getTenantForSubscription(subId)).thenReturn(tenantId);
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
-    offer.setName("FAKE_APP_NAME");
+    offer.setName(offerName);
     offer.setAuthorizedUserKey("authorizedTerraUser");
-    var offers = Map.of(offerName, offer);
+    var offers = Set.of(offer);
     var azureService =
         new AzureService(appService, new AzureConfiguration("fake", "fake", "fake", offers));
 


### PR DESCRIPTION
## Context
[Relevant ticket](https://broadworkbench.atlassian.net/jira/software/c/projects/WOR/boards/125/backlog?view=detail&selectedIssue=WOR-454&issueLimit=100)

The way "well-known" Azure marketplace offers is configured in BPM is awkward and difficult to modify via helmfiles. 

(Quick refresher: well known offers are those Azure application offers whose deployments BPM will allow to be linked to billing profiles)

Specifically, having the offer name be a key and the auth'ed user key be a value makes setting the config via OS environment variables intractable in my research.


## This PR
* Restructures how we configure well known application offers. The config is now an array of offer objects, with the keys being the offer name and the authed user key. The knock-on effect here is that we are able to set the offers via environment variables like so:
   * `PROFILE_AZURE_APPLICATIONOFFERS_0_NAME=foo;PROFILE_AZURE_APPLICATIONOFFERS_0_AUTHORIZEDUSERKEY=bar`
* [or via a helmfile change](https://github.com/broadinstitute/terra-helmfile/pull/3223/files)