### PR TITLE
[WOR-497] set environment in sentry configuration

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/profile/app/StartupInitializer.java
@@ -41,6 +41,7 @@ public final class StartupInitializer {
       Sentry.init(
           options -> {
             options.setDsn(sentryConfiguration.dsn());
+            options.setEnvironment(sentryConfiguration.environment());
           });
     }
     // TODO: Fill in this method with any other initialization that needs to happen

--- a/service/src/main/java/bio/terra/profile/app/configuration/SentryConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/SentryConfiguration.java
@@ -3,4 +3,4 @@ package bio.terra.profile.app.configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "profile.sentry")
-public record SentryConfiguration(String dsn) {}
+public record SentryConfiguration(String dsn, String environment) {}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-# All env variables that are used in one place
+# All environment variables that are used in one place
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
@@ -24,6 +24,7 @@ env:
     managedAppTenantId: ${MANAGED_APP_TENANT_ID:app-tenant}
   sentry:
     dsn: ${SENTRY_DSN:}
+    environment: ${DEPLOY_ENV:}
 
 # Below here is non-deployment-specific
 
@@ -96,6 +97,7 @@ profile:
 
   sentry:
     dsn: ${env.sentry.dsn}
+    environment: ${env.sentry.environment}
 
 terra.common:
   kubernetes:


### PR DESCRIPTION
Ticket: [WOR-497](https://broadworkbench.atlassian.net/browse/WOR-497)
* Setting the environment in sentry's configuration will let us use the same Sentry project and still know which environment the issue is happening in
* Related terra-helmfile PR - https://github.com/broadinstitute/terra-helmfile/pull/3266