### PR TITLE
[WOR-391] Implement Sam passthroughs for profile policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Then, to build the code, run:
 ./gradlew build
 ```
 
+Troubleshooting:
+* If you run into an error about `minney-kinney`, execute:
+
+```sh
+./minnie-kenny.sh --force   
+```
+* The build also runs the tests, so the tests will fail unless `postgres` is running (see next step).
+
 ## Running the tests
 
 For tests, ensure you have a local Postgres instance running. While in the
@@ -34,7 +42,7 @@ After the database is initialized, run unit tests:
 ./gradlew test
 ```
 
-To set up serrvice account credentials and other configuration for running locally:
+To set up service account credentials and other configuration for running locally:
 * Install yq `brew install yq`
 * Run `render-configs.sh`
 
@@ -45,9 +53,22 @@ sleep 5                # wait until service comes up
 ./gradlew :integration:runTest --args="suites/FullIntegration.json /tmp/test"
 ```
 
+## Running Billing Profile Manager Locally
+
+```sh
+./gradlew :service:bootRun
+```
+
+Then navigate to the Swagger: http://localhost:8080/swagger-ui.html
+
 ## Linter
 Automatically fix linting issues:
 ```
 ./gradlew spotlessApply
 ```
 
+## Generate Java classes from Swagger documentation (.yml file definition)
+
+```sh
+./gradlew generateSwaggerCode
+```

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	implementation group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-common'
 
 	// Sam
-	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.12", version: "0.1-61135c7"
+	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-c53306a-SNAP"
 
 	// Test deps
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
@@ -80,7 +80,7 @@ public class ProfileApiController implements ProfileApi {
   public ResponseEntity<SamPolicyModelList> getProfilePolicies(@PathVariable("profileId") UUID id) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     List<SamPolicyModel> policies = profileService.getProfilePolicies(id, user);
-    var response = new SamPolicyModelList().items(new ArrayList<>(policies));
+    var response = new SamPolicyModelList().items(policies);
 
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
@@ -9,7 +9,6 @@ import bio.terra.profile.service.job.JobService;
 import bio.terra.profile.service.profile.ProfileService;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -86,27 +85,25 @@ public class ProfileApiController implements ProfileApi {
   }
 
   @Override
-  public ResponseEntity<PolicyResponse> addProfilePolicyMember(
+  public ResponseEntity<SamPolicyModel> addProfilePolicyMember(
       @PathVariable("profileId") UUID id,
       @PathVariable("policyName") String policyName,
       @PathVariable("memberEmail") String memberEmail) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     SamPolicyModel policy =
         profileService.addProfilePolicyMember(id, policyName, memberEmail, user);
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(policy, HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<PolicyResponse> deleteProfilePolicyMember(
+  public ResponseEntity<SamPolicyModel> deleteProfilePolicyMember(
       @PathVariable("profileId") UUID id,
       @PathVariable("policyName") String policyName,
       @PathVariable("memberEmail") String memberEmail) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     SamPolicyModel policy =
         profileService.deleteProfilePolicyMember(id, policyName, memberEmail, user);
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return new ResponseEntity<>(policy, HttpStatus.OK);
   }
 
   /**

--- a/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
@@ -87,24 +87,24 @@ public class ProfileApiController implements ProfileApi {
 
   @Override
   public ResponseEntity<PolicyResponse> addProfilePolicyMember(
-         @PathVariable("profileId") UUID id,
-         @PathVariable("policyName") String policyName,
-         @PathVariable("memberEmail") String memberEmail
- ) {
-   AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-   SamPolicyModel policy = profileService.addProfilePolicyMember(id, policyName, memberEmail, user);
-   PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
-   return new ResponseEntity<>(response, HttpStatus.OK);
- }
+      @PathVariable("profileId") UUID id,
+      @PathVariable("policyName") String policyName,
+      @PathVariable("memberEmail") String memberEmail) {
+    AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
+    SamPolicyModel policy =
+        profileService.addProfilePolicyMember(id, policyName, memberEmail, user);
+    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
 
   @Override
   public ResponseEntity<PolicyResponse> deleteProfilePolicyMember(
-          @PathVariable("profileId") UUID id,
-          @PathVariable("policyName") String policyName,
-          @PathVariable("memberEmail") String memberEmail
-  ) {
+      @PathVariable("profileId") UUID id,
+      @PathVariable("policyName") String policyName,
+      @PathVariable("memberEmail") String memberEmail) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-    SamPolicyModel policy = profileService.deleteProfilePolicyMember(id, policyName, memberEmail, user);
+    SamPolicyModel policy =
+        profileService.deleteProfilePolicyMember(id, policyName, memberEmail, user);
     PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
@@ -4,13 +4,12 @@ import bio.terra.common.exception.ValidationException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.profile.api.ProfileApi;
-import bio.terra.profile.model.CreateProfileRequest;
-import bio.terra.profile.model.ProfileModel;
-import bio.terra.profile.model.ProfileModelList;
+import bio.terra.profile.model.*;
 import bio.terra.profile.service.job.JobService;
 import bio.terra.profile.service.profile.ProfileService;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -75,6 +74,39 @@ public class ProfileApiController implements ProfileApi {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     profileService.deleteProfile(id, user);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @Override
+  public ResponseEntity<SamPolicyModelList> getProfilePolicies(@PathVariable("profileId") UUID id) {
+    AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
+    List<SamPolicyModel> policies = profileService.getProfilePolicies(id, user);
+    var response = new SamPolicyModelList().items(new ArrayList<>(policies));
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<PolicyResponse> addProfilePolicyMember(
+         @PathVariable("profileId") UUID id,
+         @PathVariable("policyName") String policyName,
+         @PathVariable("memberEmail") String memberEmail
+ ) {
+   AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
+   SamPolicyModel policy = profileService.addProfilePolicyMember(id, policyName, memberEmail, user);
+   PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+   return new ResponseEntity<>(response, HttpStatus.OK);
+ }
+
+  @Override
+  public ResponseEntity<PolicyResponse> deleteProfilePolicyMember(
+          @PathVariable("profileId") UUID id,
+          @PathVariable("policyName") String policyName,
+          @PathVariable("memberEmail") String memberEmail
+  ) {
+    AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
+    SamPolicyModel policy = profileService.deleteProfilePolicyMember(id, policyName, memberEmail, user);
+    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   /**

--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -203,72 +203,75 @@ public class SamService {
   }
 
   public SamPolicyModel addPolicyMember(
-          AuthenticatedUserRequest userReq,
-          SamResourceType iamResourceType,
-          UUID resourceId,
-          String policyName,
-          String userEmail)
-          throws InterruptedException {
+      AuthenticatedUserRequest userReq,
+      SamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      String userEmail)
+      throws InterruptedException {
     try {
-      return SamRetry.retry(() -> addPolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
+      return SamRetry.retry(
+          () -> addPolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
     } catch (ApiException e) {
       throw SamExceptionFactory.create("Error adding policy member in Sam", e);
     }
   }
 
   private SamPolicyModel addPolicyMemberInner(
-          AuthenticatedUserRequest userReq,
-          SamResourceType iamResourceType,
-          UUID resourceId,
-          String policyName,
-          String userEmail)
-          throws ApiException {
+      AuthenticatedUserRequest userReq,
+      SamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      String userEmail)
+      throws ApiException {
     ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
     logger.debug(
-            "addUserPolicy resourceType {} resourceId {} policyName {} userEmail {}",
-            iamResourceType.toString(),
-            resourceId.toString(),
-            policyName,
-            userEmail);
+        "addUserPolicy resourceType {} resourceId {} policyName {} userEmail {}",
+        iamResourceType.toString(),
+        resourceId.toString(),
+        policyName,
+        userEmail);
     samResourceApi.addUserToPolicyV2(
-            iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
+        iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
     AccessPolicyMembershipV2 result =
-            samResourceApi.getPolicyV2(iamResourceType.toString(), resourceId.toString(), policyName);
+        samResourceApi.getPolicyV2(iamResourceType.toString(), resourceId.toString(), policyName);
     return new SamPolicyModel().name(policyName).members(result.getMemberEmails());
   }
 
   public SamPolicyModel deletePolicyMember(
-          AuthenticatedUserRequest userReq,
-          SamResourceType iamResourceType,
-          UUID resourceId,
-          String policyName,
-          String userEmail)
-          throws InterruptedException {
+      AuthenticatedUserRequest userReq,
+      SamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      String userEmail)
+      throws InterruptedException {
     try {
-      return SamRetry.retry(() -> deletePolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
+      return SamRetry.retry(
+          () ->
+              deletePolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
     } catch (ApiException e) {
-      throw SamExceptionFactory.create("Error adding policy member in Sam", e);
+      throw SamExceptionFactory.create("Error deleting policy member in Sam", e);
     }
   }
 
   private SamPolicyModel deletePolicyMemberInner(
-          AuthenticatedUserRequest userReq,
-          SamResourceType iamResourceType,
-          UUID resourceId,
-          String policyName,
-          String userEmail)
-        throws ApiException {
+      AuthenticatedUserRequest userReq,
+      SamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      String userEmail)
+      throws ApiException {
     ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
     logger.debug(
-            "addUserPolicy resourceType {} resourceId {} policyName {} userEmail {}",
-            iamResourceType.toString(),
-            resourceId.toString(),
-            policyName,
-            userEmail);
+        "removeUserPolicy resourceType {} resourceId {} policyName {} userEmail {}",
+        iamResourceType.toString(),
+        resourceId.toString(),
+        policyName,
+        userEmail);
     samResourceApi.removeUserFromPolicyV2(
-            iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
+        iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
     AccessPolicyMembershipV2 result =
-            samResourceApi.getPolicyV2(iamResourceType.toString(), resourceId.toString(), policyName);
+        samResourceApi.getPolicyV2(iamResourceType.toString(), resourceId.toString(), policyName);
     return new SamPolicyModel().name(policyName).members(result.getMemberEmails());
   }
 

--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -187,7 +187,7 @@ public class SamService {
                   new SamPolicyModel()
                       .name(entry.getPolicyName())
                       .members(entry.getPolicy().getMemberEmails()))
-              .collect(Collectors.toList());
+          .collect(Collectors.toList());
     }
   }
 

--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -5,7 +5,6 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.sam.SamRetry;
 import bio.terra.common.sam.exception.SamExceptionFactory;
 import bio.terra.profile.app.configuration.SamConfiguration;
-import bio.terra.profile.model.ResourcePolicyModel;
 import bio.terra.profile.model.SamPolicyModel;
 import bio.terra.profile.model.SystemStatusSystems;
 import bio.terra.profile.service.iam.model.SamAction;
@@ -187,18 +186,8 @@ public class SamService {
               entry ->
                   new SamPolicyModel()
                       .name(entry.getPolicyName())
-                      .members(entry.getPolicy().getMemberEmails())
-                      .memberPolicies(
-                          entry.getPolicy().getMemberPolicies().stream()
-                              .map(
-                                  pid ->
-                                      new ResourcePolicyModel()
-                                          .policyName(pid.getPolicyName())
-                                          .policyEmail(pid.getPolicyEmail())
-                                          .resourceId(UUID.fromString(pid.getResourceId()))
-                                          .resourceTypeName(pid.getResourceTypeName()))
-                              .collect(Collectors.toList())))
-          .collect(Collectors.toList());
+                      .members(entry.getPolicy().getMemberEmails()))
+              .collect(Collectors.toList());
     }
   }
 

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -3,6 +3,7 @@ package bio.terra.profile.service.profile;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
+import bio.terra.profile.model.SamPolicyModel;
 import bio.terra.profile.service.iam.SamRethrow;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.iam.model.SamAction;
@@ -110,5 +111,25 @@ public class ProfileService {
     List<UUID> samProfileIds =
         SamRethrow.onInterrupted(() -> samService.listProfileIds(user), "listProfileIds");
     return profileDao.listBillingProfiles(offset, limit, samProfileIds);
+  }
+
+  public List<SamPolicyModel> getProfilePolicies(UUID profileId, AuthenticatedUserRequest user) {
+    List<SamPolicyModel> samPolicies =
+        SamRethrow.onInterrupted(
+            () -> samService.retrievePolicies(user, SamResourceType.PROFILE, profileId),
+            "retrievePolicies");
+    return samPolicies;
+  }
+
+  public SamPolicyModel addProfilePolicyMember(UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+    return SamRethrow.onInterrupted(
+            () -> samService.addPolicyMember(user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
+            "addPolicyMember");
+  }
+
+  public SamPolicyModel deleteProfilePolicyMember(UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+    return SamRethrow.onInterrupted(
+            () -> samService.deletePolicyMember(user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
+            "deletePolicyMember");
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -121,15 +121,21 @@ public class ProfileService {
     return samPolicies;
   }
 
-  public SamPolicyModel addProfilePolicyMember(UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+  public SamPolicyModel addProfilePolicyMember(
+      UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
     return SamRethrow.onInterrupted(
-            () -> samService.addPolicyMember(user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
-            "addPolicyMember");
+        () ->
+            samService.addPolicyMember(
+                user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
+        "addPolicyMember");
   }
 
-  public SamPolicyModel deleteProfilePolicyMember(UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+  public SamPolicyModel deleteProfilePolicyMember(
+      UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
     return SamRethrow.onInterrupted(
-            () -> samService.deletePolicyMember(user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
-            "deletePolicyMember");
+        () ->
+            samService.deletePolicyMember(
+                user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
+        "deletePolicyMember");
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -114,28 +114,21 @@ public class ProfileService {
   }
 
   public List<SamPolicyModel> getProfilePolicies(UUID profileId, AuthenticatedUserRequest user) {
-    List<SamPolicyModel> samPolicies =
-        SamRethrow.onInterrupted(
-            () -> samService.retrievePolicies(user, SamResourceType.PROFILE, profileId),
-            "retrievePolicies");
-    return samPolicies;
+    return SamRethrow.onInterrupted(
+        () -> samService.retrieveProfilePolicies(user, profileId), "retrieveProfilePolicies");
   }
 
   public SamPolicyModel addProfilePolicyMember(
       UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
     return SamRethrow.onInterrupted(
-        () ->
-            samService.addPolicyMember(
-                user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
-        "addPolicyMember");
+        () -> samService.addProfilePolicyMember(user, profileId, policyName, memberEmail),
+        "addProfilePolicyMember");
   }
 
   public SamPolicyModel deleteProfilePolicyMember(
       UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
     return SamRethrow.onInterrupted(
-        () ->
-            samService.deletePolicyMember(
-                user, SamResourceType.PROFILE, profileId, policyName, memberEmail),
+        () -> samService.deleteProfilePolicyMember(user, profileId, policyName, memberEmail),
         "deletePolicyMember");
   }
 }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -145,6 +145,83 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/profiles/v1/{profileId}/policies:
+    parameters:
+      - $ref: '#/components/parameters/ProfileId'
+    get:
+      tags:
+        - Profile
+        - Resources
+      summary: Retrieve policies for the profile
+      operationId: getProfilePolicies
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SamPolicyModelList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/profiles/v1/{profileId}/policies/{policyName}/members/{memberEmail}:
+    post:
+      tags:
+        - Profile
+        - Resources
+      description: >
+        Adds a member to the specified policy for the profile.
+        NOTE: Change may take up to 60 seconds to take effect.
+      operationId: addProfilePolicyMember
+      parameters:
+        - $ref: '#/components/parameters/ProfileId'
+        - $ref: '#/components/parameters/ProfilePolicyName'
+        - $ref: '#/components/parameters/MemberEmail'
+      responses:
+        201:
+          description: Policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/resources/v1/profiles/{profileId}/policies/{policyName}/members/{memberEmail}:
+    delete:
+      tags:
+        - Profile
+        - Resources
+      description: >
+        Removes a member from the specified policy for the profile.
+        NOTE: Change may take up to 60 seconds to take effect.
+      operationId: deleteProfilePolicyMember
+      parameters:
+        - $ref: '#/components/parameters/ProfileId'
+        - $ref: '#/components/parameters/ProfilePolicyName'
+        - $ref: '#/components/parameters/MemberEmail'
+      responses:
+        '200':
+          description: Policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/azure/v1/managedApps:
     get:
       parameters:
@@ -186,6 +263,26 @@ components:
       schema:
         type: string
         format: uuid
+
+    ProfilePolicyName:
+      name: policyName
+      in: path
+      description: The relevant policy
+      required: true
+      schema:
+        type: string
+        enum:
+          - owner
+          - user
+          - admin
+
+    MemberEmail:
+      name: memberEmail
+      in: path
+      description: The email of the user to add or remove policies for
+      required: true
+      schema:
+        type: string
 
     JobId:
       name: jobId
@@ -286,6 +383,22 @@ components:
       description: >
         The total number of billing profiles available and a page of profiles
 
+    SamPolicyModelList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SamPolicyModel'
+
+    PolicyResponse:
+      type: object
+      properties:
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/SamPolicyModel'
+
     AzureManagedAppsResponseModel:
       type: object
       properties:
@@ -317,6 +430,33 @@ components:
           format: uuid
           description: Azure tenant ID containing the Terra app deployment
 
+    ResourcePolicyModel:
+      type: object
+      properties:
+        policyEmail:
+          type: string
+        policyName:
+          type: string
+        resourceId:
+          description: Unique identifier of policy
+        resourceTypeName:
+          type: string
+
+    SamPolicyModel:
+      type: object
+      properties:
+        name:
+          type: string
+        members:
+          type: array
+          items:
+            type: string
+        memberPolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourcePolicyModel'
+      description: >
+        Describes a policy from Sam, with member policies    
 
     ProfileModel:
       type: object
@@ -448,13 +588,6 @@ components:
       enum: [ 'AZURE', 'GCP' ]
 
   responses:
-    CreateProfileResultResponse:
-      description: Job is complete (succeeded or failed)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CreateProfileResult'
-
     StatusResponse:
       description: common status response
       content:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -173,7 +173,6 @@ paths:
         - Profile
       description: >
         Adds a member to the specified policy for the profile.
-        NOTE: Change may take up to 60 seconds to take effect.
       operationId: addProfilePolicyMember
       parameters:
         - $ref: '#/components/parameters/ProfileId'
@@ -199,7 +198,6 @@ paths:
         - Profile
       description: >
         Removes a member from the specified policy for the profile.
-        NOTE: Change may take up to 60 seconds to take effect.
       operationId: deleteProfilePolicyMember
       parameters:
         - $ref: '#/components/parameters/ProfileId'

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -185,7 +185,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PolicyResponse'
+                $ref: '#/components/schemas/SamPolicyModel'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -211,7 +211,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PolicyResponse'
+                $ref: '#/components/schemas/SamPolicyModel'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -383,14 +383,6 @@ components:
       type: object
       properties:
         items:
-          type: array
-          items:
-            $ref: '#/components/schemas/SamPolicyModel'
-
-    PolicyResponse:
-      type: object
-      properties:
-        policies:
           type: array
           items:
             $ref: '#/components/schemas/SamPolicyModel'

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -274,7 +274,6 @@ components:
         enum:
           - owner
           - user
-          - admin
 
     MemberEmail:
       name: memberEmail
@@ -430,18 +429,6 @@ components:
           format: uuid
           description: Azure tenant ID containing the Terra app deployment
 
-    ResourcePolicyModel:
-      type: object
-      properties:
-        policyEmail:
-          type: string
-        policyName:
-          type: string
-        resourceId:
-          description: Unique identifier of policy
-        resourceTypeName:
-          type: string
-
     SamPolicyModel:
       type: object
       properties:
@@ -451,12 +438,8 @@ components:
           type: array
           items:
             type: string
-        memberPolicies:
-          type: array
-          items:
-            $ref: '#/components/schemas/ResourcePolicyModel'
       description: >
-        Describes a policy from Sam, with member policies    
+        Describes a policy from Sam
 
     ProfileModel:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -151,7 +151,6 @@ paths:
     get:
       tags:
         - Profile
-        - Resources
       summary: Retrieve policies for the profile
       operationId: getProfilePolicies
       responses:
@@ -172,7 +171,6 @@ paths:
     post:
       tags:
         - Profile
-        - Resources
       description: >
         Adds a member to the specified policy for the profile.
         NOTE: Change may take up to 60 seconds to take effect.
@@ -199,7 +197,6 @@ paths:
     delete:
       tags:
         - Profile
-        - Resources
       description: >
         Removes a member from the specified policy for the profile.
         NOTE: Change may take up to 60 seconds to take effect.

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -92,7 +92,7 @@ profile:
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
 
     application-offers:
-      - name: aherbst-202202024-preview
+      - name: terra-dev-preview
         authorized-user-key: authorizedTerraUser
 
   sentry:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -92,7 +92,7 @@ profile:
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
 
     application-offers:
-      - name: terra-workspace-dev
+      - name: aherbst-202202024-preview
         authorized-user-key: authorizedTerraUser
 
   sentry:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'terra-billing-profile-manager'
 include('service', 'client')
 
-gradle.ext.releaseVersion = '0.1.19-SNAPSHOT'
+gradle.ext.releaseVersion = '0.1.20-SNAPSHOT'


### PR DESCRIPTION
Implements these endpoints for policies "user" and "owner", which map to roles "user" and "owner" respectively.

* GET /api/profiles/v1/{profileId}/policies

List the Sam resource policies for a billing profile.

* POST ​/api​/profiles/v1​/{profileId}​/policies​/{policyName}​/members​/{memberEmail}

Adds a member to the specified policy for the billing profile

* DELETE ​/api​/profiles/v1​/{profileId}​/policies​/{policyName}​/members​/{memberEmail}

Removes a member from the specified policy for the profile

The only information returned about a policy is its name and the member emails. For some discussion on this, see https://broadworkbench.atlassian.net/browse/WOR-391?focusedCommentId=66574
