### PR TITLE
[WOR-387] Switch email from URL param to body.

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
@@ -88,10 +88,10 @@ public class ProfileApiController implements ProfileApi {
   public ResponseEntity<SamPolicyModel> addProfilePolicyMember(
       @PathVariable("profileId") UUID id,
       @PathVariable("policyName") String policyName,
-      @PathVariable("memberEmail") String memberEmail) {
+      @RequestBody PolicyMemberRequest requestBody) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     SamPolicyModel policy =
-        profileService.addProfilePolicyMember(id, policyName, memberEmail, user);
+        profileService.addProfilePolicyMember(id, policyName, requestBody.getEmail(), user);
     return new ResponseEntity<>(policy, HttpStatus.OK);
   }
 

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -167,7 +167,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /api/profiles/v1/{profileId}/policies/{policyName}/members/{memberEmail}:
+  /api/profiles/v1/{profileId}/policies/{policyName}/members:
     post:
       tags:
         - Profile
@@ -177,7 +177,12 @@ paths:
       parameters:
         - $ref: '#/components/parameters/ProfileId'
         - $ref: '#/components/parameters/ProfilePolicyName'
-        - $ref: '#/components/parameters/MemberEmail'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyMemberRequest'
       responses:
         201:
           description: Policy
@@ -273,7 +278,7 @@ components:
     MemberEmail:
       name: memberEmail
       in: path
-      description: The email of the user to add or remove policies for
+      description: The email of the user to remove policies for
       required: true
       schema:
         type: string
@@ -427,6 +432,15 @@ components:
             type: string
       description: >
         Describes a policy from Sam
+
+    PolicyMemberRequest:
+      required:
+        - email
+      type: object
+      properties:
+        email:
+          description: The email of the user to add policies for
+          type: string
 
     ProfileModel:
       type: object


### PR DESCRIPTION
Switch the API to specify the email address in the  body because the Java client errors with no body present. I tried specifying an empty body, but that actually led to a less intuitive API, and I still couldn't get it to work (problems serializing an empty bean).

FWIW, this change makes the API match the [jade-data-repo one](https://github.com/DataBiosphere/jade-data-repo/blob/aa3320d38cf88eadfb31fca4ced3777f14080e29/src/main/resources/api/data-repository-openapi.yaml#L354).