### PR TITLE
[WOR-520] Tag Azure MRG with billing profile ID

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -40,14 +40,14 @@ public class ApplicationService {
   }
 
   /**
-   * Adds a tag to the MRG associated with a given profile. If the tag is already present, * throws
-   * a DuplicateTagException.
+   * Adds a tag to the MRG associated with a given profile.
    *
    * @param tenantId Tenant ID associated with the MRG
    * @param subscriptionId Subscription ID associated with the MRG
    * @param managedResourceGroupId ID for the MRG
    * @param tag Tag name
    * @param value Tag value
+   * @throws DuplicateTagException if the tag is already present.
    */
   public void addTagToMrg(
       UUID tenantId, UUID subscriptionId, String managedResourceGroupId, String tag, String value) {

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -58,8 +58,8 @@ public class ApplicationService {
     if (existing != null) {
       throw new DuplicateTagException(
           String.format(
-              "MRG has existing tag [mrg_id = %s, existing tag = %s]",
-              managedResourceGroupId, existing));
+              "MRG has existing tag [mrg_id = %s, existing tag = %s, value = %s]",
+              managedResourceGroupId, tag, existing));
     }
 
     // dupe existing tags to a mutable hashmap

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -1,7 +1,9 @@
 package bio.terra.profile.service.azure;
 
 import bio.terra.profile.service.crl.CrlService;
+import bio.terra.profile.service.profile.exception.DuplicateTagException;
 import com.azure.resourcemanager.managedapplications.models.Application;
+import java.util.HashMap;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ApplicationService {
+
   private final CrlService crlService;
 
   @Autowired
@@ -16,12 +19,53 @@ public class ApplicationService {
     this.crlService = crlService;
   }
 
+  /**
+   * Retrieves the managed applications for a given Azure subscription
+   *
+   * @param subscriptionId Azure subscription ID to be queried
+   * @return List of managed applications present in the subscription
+   */
   public Stream<Application> getApplicationsForSubscription(UUID subscriptionId) {
     var appMgr = crlService.getApplicationManager(subscriptionId);
     return appMgr.applications().list().stream();
   }
 
+  /**
+   * Retrieves the tenant associated with a given Azure subscription ID
+   *
+   * @param subscriptionId Azure subscription ID to be queried
+   * @return UUID for the associated tenant
+   */
   public UUID getTenantForSubscription(UUID subscriptionId) {
     return crlService.getTenantForSubscription(subscriptionId);
+  }
+
+  /**
+   * Adds a tag to the MRG associated with a given profile. If the tag is already present, * throws
+   * a DuplicateTagException.
+   *
+   * @param tenantId Tenant ID associated with the MRG
+   * @param subscriptionId Subscription ID associated with the MRG
+   * @param managedResourceGroupId ID for the MRG
+   * @param tag Tag name
+   * @param value Tag value
+   */
+  public void addTagToMrg(
+      UUID tenantId, UUID subscriptionId, String managedResourceGroupId, String tag, String value) {
+
+    var mrgResource = crlService.getResourceGroup(tenantId, subscriptionId, managedResourceGroupId);
+    var existingTags = mrgResource.tags();
+    var existing = existingTags.get(tag);
+    if (existing != null) {
+      throw new DuplicateTagException(
+          String.format(
+              "MRG has existing tag [mrg_id = %s, existing tag = %s]",
+              managedResourceGroupId, existing));
+    }
+
+    // dupe existing tags to a mutable hashmap
+    HashMap<String, String> tags = new HashMap<>(mrgResource.tags());
+    tags.put(tag, value);
+    crlService.updateTagsForResource(tenantId, subscriptionId, managedResourceGroupId, tags);
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ApplicationService {
-
   private final CrlService crlService;
 
   @Autowired

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class AzureService {
   private static final Logger logger = LoggerFactory.getLogger(AzureService.class);
+
   private final ApplicationService appService;
   private final Set<AzureConfiguration.AzureApplicationOffer> azureAppOffers;
 

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class AzureService {
   private static final Logger logger = LoggerFactory.getLogger(AzureService.class);
-
   private final ApplicationService appService;
   private final Set<AzureConfiguration.AzureApplicationOffer> azureAppOffers;
 

--- a/service/src/main/java/bio/terra/profile/service/crl/CrlService.java
+++ b/service/src/main/java/bio/terra/profile/service/crl/CrlService.java
@@ -11,9 +11,11 @@ import com.azure.core.management.profile.AzureProfile;
 import com.azure.resourcemanager.managedapplications.ApplicationManager;
 import com.azure.resourcemanager.resources.ResourceManager;
 import com.azure.resourcemanager.resources.fluent.SubscriptionClient;
+import com.azure.resourcemanager.resources.models.ResourceGroup;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -70,6 +72,17 @@ public class CrlService {
     SubscriptionClient sc = resourceManager.subscriptionClient();
     var subscription = sc.getSubscriptions().get(subscriptionId.toString());
     return UUID.fromString(subscription.tenantId());
+  }
+
+  public ResourceGroup getResourceGroup(UUID tenantId, UUID subscriptionId, String resourceId) {
+    var resourceManager = getResourceManager(tenantId, subscriptionId);
+    return resourceManager.resourceGroups().getByName(resourceId);
+  }
+
+  public void updateTagsForResource(
+      UUID tenantId, UUID subscriptionId, String resourceId, Map<String, String> tags) {
+    var resourceManager = getResourceManager(tenantId, subscriptionId);
+    resourceManager.tagOperations().updateTags(resourceId, tags);
   }
 
   private ClientConfig buildClientConfig() {

--- a/service/src/main/java/bio/terra/profile/service/profile/exception/DuplicateTagException.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/exception/DuplicateTagException.java
@@ -1,0 +1,17 @@
+package bio.terra.profile.service.profile.exception;
+
+import bio.terra.common.exception.ConflictException;
+
+public class DuplicateTagException extends ConflictException {
+  public DuplicateTagException(String message) {
+    super(message);
+  }
+
+  public DuplicateTagException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DuplicateTagException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
@@ -35,6 +35,7 @@ public class CreateProfileFlight extends Flight {
         break;
       case AZURE:
         addStep(new CreateProfileVerifyDeployedApplicationStep(azureService, profile, user));
+        addStep(new LinkBillingProfileIdToMrgStep(crlService, azureService, profile, user));
         break;
     }
     addStep(new CreateProfileAuthzIamStep(samService, profile, user));

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
@@ -35,7 +35,7 @@ public class CreateProfileFlight extends Flight {
         break;
       case AZURE:
         addStep(new CreateProfileVerifyDeployedApplicationStep(azureService, profile, user));
-        addStep(new LinkBillingProfileIdToMrgStep(crlService, azureService, profile, user));
+        addStep(new LinkBillingProfileIdToMrgStep(crlService, profile, user));
         break;
     }
     addStep(new CreateProfileAuthzIamStep(samService, profile, user));

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
@@ -2,6 +2,7 @@ package bio.terra.profile.service.profile.flight.create;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
+import bio.terra.profile.service.azure.ApplicationService;
 import bio.terra.profile.service.azure.AzureService;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.iam.SamService;
@@ -21,6 +22,7 @@ public class CreateProfileFlight extends Flight {
     CrlService crlService = appContext.getBean(CrlService.class);
     SamService samService = appContext.getBean(SamService.class);
     AzureService azureService = appContext.getBean(AzureService.class);
+    ApplicationService appService = appContext.getBean(ApplicationService.class);
 
     BillingProfile profile =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BillingProfile.class);
@@ -35,7 +37,7 @@ public class CreateProfileFlight extends Flight {
         break;
       case AZURE:
         addStep(new CreateProfileVerifyDeployedApplicationStep(azureService, profile, user));
-        addStep(new LinkBillingProfileIdToMrgStep(crlService, profile, user));
+        addStep(new LinkBillingProfileIdToMrgStep(appService, profile, user));
         break;
     }
     addStep(new CreateProfileAuthzIamStep(samService, profile, user));

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
@@ -37,7 +37,7 @@ public class CreateProfileFlight extends Flight {
         break;
       case AZURE:
         addStep(new CreateProfileVerifyDeployedApplicationStep(azureService, profile, user));
-        addStep(new LinkBillingProfileIdToMrgStep(appService, profile, user));
+        addStep(new LinkBillingProfileIdToMrgStep(appService, profile));
         break;
     }
     addStep(new CreateProfileAuthzIamStep(samService, profile, user));

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -1,8 +1,7 @@
 package bio.terra.profile.service.profile.flight.create;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.service.crl.CrlService;
-import bio.terra.profile.service.profile.exception.DuplicateProfileException;
+import bio.terra.profile.service.azure.ApplicationService;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.FlightContext;
@@ -10,44 +9,35 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
-import java.util.HashMap;
 
 /** Add a tag that associates a billing profile ID with an azure managed resource group */
 public record LinkBillingProfileIdToMrgStep(
-    CrlService crlService, BillingProfile profile, AuthenticatedUserRequest user) implements Step {
+    ApplicationService applicationService, BillingProfile profile, AuthenticatedUserRequest user)
+    implements Step {
   private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     try {
-      validateBillingProfile();
-
-      var resourceManager =
-          crlService.getResourceManager(profile.tenantId().get(), profile.subscriptionId().get());
-      var resource =
-          resourceManager.resourceGroups().getByName(profile.managedResourceGroupId().get());
-
-      var existingTags = resource.tags();
-      var existing = existingTags.get(BILLING_PROFILE_ID_TAG);
-      if (existing != null) {
-        throw new DuplicateProfileException(
-            String.format(
-                "MRG has existing billing profile linked [mrg_id = %s, existing billing_profile_id = %s]",
-                profile.managedResourceGroupId().get(), existing));
-      }
-
-      // dupe existing tags to a mutable hashmap
-      HashMap<String, String> tags = new HashMap<>(resource.tags());
-      tags.put(BILLING_PROFILE_ID_TAG, profile.id().toString());
-      resourceManager.tagOperations().updateTags(resource.id(), tags);
-
+      validateBillingProfile(profile);
+      applicationService.addTagToMrg(
+          profile.tenantId().get(),
+          profile.subscriptionId().get(),
+          profile.managedResourceGroupId().get(),
+          BILLING_PROFILE_ID_TAG,
+          profile.id().toString());
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
   }
 
-  private void validateBillingProfile() {
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+
+  private void validateBillingProfile(BillingProfile profile) {
     if (profile.tenantId().isEmpty()) {
       throw new MissingRequiredFieldsException(
           "No tenant ID on billing profile ID " + profile.id());
@@ -59,10 +49,5 @@ public record LinkBillingProfileIdToMrgStep(
     if (profile.managedResourceGroupId().isEmpty()) {
       throw new MissingRequiredFieldsException("No MRG ID on billing profile ID " + profile.id());
     }
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
-    return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -1,7 +1,6 @@
 package bio.terra.profile.service.profile.flight.create;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.profile.service.azure.AzureService;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.DuplicateProfileException;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
@@ -12,20 +11,11 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.HashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/**
- * Add a tag that associates a billing profile ID with an azure managed resource group
- */
+/** Add a tag that associates a billing profile ID with an azure managed resource group */
 public record LinkBillingProfileIdToMrgStep(
-    CrlService crlService,
-    AzureService azureService,
-    BillingProfile profile,
-    AuthenticatedUserRequest user)
-    implements Step {
+    CrlService crlService, BillingProfile profile, AuthenticatedUserRequest user) implements Step {
   private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
-  private static final Logger logger = LoggerFactory.getLogger(LinkBillingProfileIdToMrgStep.class);
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -1,6 +1,5 @@
 package bio.terra.profile.service.profile.flight.create;
 
-import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.service.azure.ApplicationService;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import bio.terra.profile.service.profile.model.BillingProfile;
@@ -12,8 +11,7 @@ import bio.terra.stairway.exception.RetryException;
 
 /** Add a tag that associates a billing profile ID with an azure managed resource group */
 public record LinkBillingProfileIdToMrgStep(
-    ApplicationService applicationService, BillingProfile profile)
-    implements Step {
+    ApplicationService applicationService, BillingProfile profile) implements Step {
   private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
 
   @Override

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -1,0 +1,78 @@
+package bio.terra.profile.service.profile.flight.create;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.profile.service.azure.AzureService;
+import bio.terra.profile.service.crl.CrlService;
+import bio.terra.profile.service.profile.exception.DuplicateProfileException;
+import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
+import bio.terra.profile.service.profile.model.BillingProfile;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import java.util.HashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Add a tag that associates a billing profile ID with an azure managed resource group
+ */
+public record LinkBillingProfileIdToMrgStep(
+    CrlService crlService,
+    AzureService azureService,
+    BillingProfile profile,
+    AuthenticatedUserRequest user)
+    implements Step {
+  private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
+  private static final Logger logger = LoggerFactory.getLogger(LinkBillingProfileIdToMrgStep.class);
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    try {
+      validateBillingProfile();
+
+      var resourceManager =
+          crlService.getResourceManager(profile.tenantId().get(), profile.subscriptionId().get());
+      var resource =
+          resourceManager.resourceGroups().getByName(profile.managedResourceGroupId().get());
+
+      var existingTags = resource.tags();
+      var existing = existingTags.get(BILLING_PROFILE_ID_TAG);
+      if (existing != null) {
+        throw new DuplicateProfileException(
+            String.format(
+                "MRG has existing billing profile linked [mrg_id = %s, existing billing_profile_id = %s]",
+                profile.managedResourceGroupId().get(), existing));
+      }
+
+      // dupe existing tags to a mutable hashmap
+      HashMap<String, String> tags = new HashMap<>(resource.tags());
+      tags.put(BILLING_PROFILE_ID_TAG, profile.id().toString());
+      resourceManager.tagOperations().updateTags(resource.id(), tags);
+
+      return StepResult.getStepResultSuccess();
+    } catch (Exception ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+    }
+  }
+
+  private void validateBillingProfile() {
+    if (profile.tenantId().isEmpty()) {
+      throw new MissingRequiredFieldsException(
+          "No tenant ID on billing profile ID " + profile.id());
+    }
+    if (profile.subscriptionId().isEmpty()) {
+      throw new MissingRequiredFieldsException(
+          "No subscription ID on billing profile ID " + profile.id());
+    }
+    if (profile.managedResourceGroupId().isEmpty()) {
+      throw new MissingRequiredFieldsException("No MRG ID on billing profile ID " + profile.id());
+    }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.exception.RetryException;
 
 /** Add a tag that associates a billing profile ID with an azure managed resource group */
 public record LinkBillingProfileIdToMrgStep(
-    ApplicationService applicationService, BillingProfile profile, AuthenticatedUserRequest user)
+    ApplicationService applicationService, BillingProfile profile)
     implements Step {
   private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
 

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -19,7 +19,18 @@ public record LinkBillingProfileIdToMrgStep(
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     try {
-      validateBillingProfile(profile);
+      if (profile.tenantId().isEmpty()) {
+        throw new MissingRequiredFieldsException(
+                "No tenant ID on billing profile ID " + profile.id());
+      }
+      if (profile.subscriptionId().isEmpty()) {
+        throw new MissingRequiredFieldsException(
+                "No subscription ID on billing profile ID " + profile.id());
+      }
+      if (profile.managedResourceGroupId().isEmpty()) {
+        throw new MissingRequiredFieldsException("No MRG ID on billing profile ID " + profile.id());
+      }
+
       applicationService.addTagToMrg(
           profile.tenantId().get(),
           profile.subscriptionId().get(),
@@ -35,19 +46,5 @@ public record LinkBillingProfileIdToMrgStep(
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     return StepResult.getStepResultSuccess();
-  }
-
-  private void validateBillingProfile(BillingProfile profile) {
-    if (profile.tenantId().isEmpty()) {
-      throw new MissingRequiredFieldsException(
-          "No tenant ID on billing profile ID " + profile.id());
-    }
-    if (profile.subscriptionId().isEmpty()) {
-      throw new MissingRequiredFieldsException(
-          "No subscription ID on billing profile ID " + profile.id());
-    }
-    if (profile.managedResourceGroupId().isEmpty()) {
-      throw new MissingRequiredFieldsException("No MRG ID on billing profile ID " + profile.id());
-    }
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -37,6 +37,7 @@ public record LinkBillingProfileIdToMrgStep(
           profile.managedResourceGroupId().get(),
           BILLING_PROFILE_ID_TAG,
           profile.id().toString());
+
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -21,11 +21,11 @@ public record LinkBillingProfileIdToMrgStep(
     try {
       if (profile.tenantId().isEmpty()) {
         throw new MissingRequiredFieldsException(
-                "No tenant ID on billing profile ID " + profile.id());
+            "No tenant ID on billing profile ID " + profile.id());
       }
       if (profile.subscriptionId().isEmpty()) {
         throw new MissingRequiredFieldsException(
-                "No subscription ID on billing profile ID " + profile.id());
+            "No subscription ID on billing profile ID " + profile.id());
       }
       if (profile.managedResourceGroupId().isEmpty()) {
         throw new MissingRequiredFieldsException("No MRG ID on billing profile ID " + profile.id());

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -19,24 +19,30 @@ public record LinkBillingProfileIdToMrgStep(
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     try {
-      if (profile.tenantId().isEmpty()) {
-        throw new MissingRequiredFieldsException(
-            "No tenant ID on billing profile ID " + profile.id());
-      }
-      if (profile.subscriptionId().isEmpty()) {
-        throw new MissingRequiredFieldsException(
-            "No subscription ID on billing profile ID " + profile.id());
-      }
-      if (profile.managedResourceGroupId().isEmpty()) {
-        throw new MissingRequiredFieldsException("No MRG ID on billing profile ID " + profile.id());
-      }
+      var tenantId =
+          profile
+              .tenantId()
+              .orElseThrow(
+                  () ->
+                      new MissingRequiredFieldsException(
+                          "No tenant ID on billing profile ID " + profile.id()));
+      var subscriptionId =
+          profile
+              .subscriptionId()
+              .orElseThrow(
+                  () ->
+                      new MissingRequiredFieldsException(
+                          "No subscription ID on billing profile ID " + profile.id()));
+      var mrgId =
+          profile
+              .managedResourceGroupId()
+              .orElseThrow(
+                  () ->
+                      new MissingRequiredFieldsException(
+                          "No MRG ID on billing profile ID " + profile.id()));
 
       applicationService.addTagToMrg(
-          profile.tenantId().get(),
-          profile.subscriptionId().get(),
-          profile.managedResourceGroupId().get(),
-          BILLING_PROFILE_ID_TAG,
-          profile.id().toString());
+          tenantId, subscriptionId, mrgId, BILLING_PROFILE_ID_TAG, profile.id().toString());
 
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -32,7 +32,7 @@ env:
 # contains the configuration of the BPM test application. We can use that application in our
 # integration testing to make sure the application code paths are working. However, we do not
 # want it to appear in production environments.
-spring.config.import: optional:file:build/resources/main/generated/local-properties.yaml
+spring.config.import: optional:file:service/build/resources/main/generated/local-properties.yaml
 
 logging.pattern.level: '%X{requestId} %5p'
 

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -1,0 +1,52 @@
+package bio.terra.profile.service.azure;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.service.crl.CrlService;
+import bio.terra.profile.service.profile.exception.DuplicateTagException;
+import com.azure.resourcemanager.resources.models.ResourceGroup;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class ApplicationServiceUnitTest extends BaseUnitTest {
+
+  @Test
+  public void addTagToMrg() {
+    var tenantId = UUID.randomUUID();
+    var subId = UUID.randomUUID();
+    var mrgId = "fake_mrg_id";
+    var crlService = mock(CrlService.class);
+    var resourceGroup = mock(ResourceGroup.class);
+    when(crlService.getResourceGroup(eq(tenantId), eq(subId), eq(mrgId))).thenReturn(resourceGroup);
+    var applicationService = new ApplicationService(crlService);
+
+    applicationService.addTagToMrg(tenantId, subId, mrgId, "fake_tag", "fake_value");
+
+    verify(crlService, times(1))
+        .updateTagsForResource(
+            eq(tenantId), eq(subId), eq(mrgId), eq(Map.of("fake_tag", "fake_value")));
+  }
+
+  @Test
+  public void addTagToMrg_failsWhenTagExists() {
+    var tenantId = UUID.randomUUID();
+    var subId = UUID.randomUUID();
+    var mrgId = "fake_mrg_id";
+    var crlService = mock(CrlService.class);
+    var resourceGroup = mock(ResourceGroup.class);
+    when(resourceGroup.tags()).thenReturn(Map.of("fake_tag", "fake_value"));
+    when(crlService.getResourceGroup(eq(tenantId), eq(subId), eq(mrgId))).thenReturn(resourceGroup);
+    var applicationService = new ApplicationService(crlService);
+
+    assertThrows(
+        DuplicateTagException.class,
+        () -> applicationService.addTagToMrg(tenantId, subId, mrgId, "fake_tag", "fake_value"));
+
+    verify(crlService, times(0).description("Should not attempt to add a tag if there is a dupe"))
+        .updateTagsForResource(any(), any(), any(), any());
+  }
+}

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -26,7 +26,7 @@ public class ApplicationServiceUnitTest extends BaseUnitTest {
 
     applicationService.addTagToMrg(tenantId, subId, mrgId, "fake_tag", "fake_value");
 
-    verify(crlService, times(1))
+    verify(crlService)
         .updateTagsForResource(
             eq(tenantId), eq(subId), eq(mrgId), eq(Map.of("fake_tag", "fake_value")));
   }

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -1,7 +1,6 @@
 package bio.terra.profile.service.azure;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import bio.terra.profile.common.BaseUnitTest;
@@ -12,34 +11,33 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
-public class ApplicationServiceUnitTest extends BaseUnitTest {
+class ApplicationServiceUnitTest extends BaseUnitTest {
 
   @Test
-  public void addTagToMrg() {
+  void addTagToMrg() {
     var tenantId = UUID.randomUUID();
     var subId = UUID.randomUUID();
     var mrgId = "fake_mrg_id";
     var crlService = mock(CrlService.class);
     var resourceGroup = mock(ResourceGroup.class);
-    when(crlService.getResourceGroup(eq(tenantId), eq(subId), eq(mrgId))).thenReturn(resourceGroup);
+    when(crlService.getResourceGroup(tenantId, subId, mrgId)).thenReturn(resourceGroup);
     var applicationService = new ApplicationService(crlService);
 
     applicationService.addTagToMrg(tenantId, subId, mrgId, "fake_tag", "fake_value");
 
     verify(crlService)
-        .updateTagsForResource(
-            eq(tenantId), eq(subId), eq(mrgId), eq(Map.of("fake_tag", "fake_value")));
+        .updateTagsForResource(tenantId, subId, mrgId, Map.of("fake_tag", "fake_value"));
   }
 
   @Test
-  public void addTagToMrg_failsWhenTagExists() {
+  void addTagToMrg_failsWhenTagExists() {
     var tenantId = UUID.randomUUID();
     var subId = UUID.randomUUID();
     var mrgId = "fake_mrg_id";
     var crlService = mock(CrlService.class);
     var resourceGroup = mock(ResourceGroup.class);
     when(resourceGroup.tags()).thenReturn(Map.of("fake_tag", "fake_value"));
-    when(crlService.getResourceGroup(eq(tenantId), eq(subId), eq(mrgId))).thenReturn(resourceGroup);
+    when(crlService.getResourceGroup(tenantId, subId, mrgId)).thenReturn(resourceGroup);
     var applicationService = new ApplicationService(crlService);
 
     assertThrows(


### PR DESCRIPTION
## Context
([Related ticket)](https://broadworkbench.atlassian.net/browse/WOR-520)
We need to tag an MRG with a billing profile ID at the time of creation so Sam can use it when creating a pet managed identity. This came up during testing in a BEE, while attempting to add a VM to an MRG for a workspace.

## This PR
* Adds a new step to the azure create profile flight, which adds a tag to the MRG with the billing profile ID. 
* Adds related tests