### PR TITLE
[WOR-502] Use fully qualified ID when setting tags

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -65,6 +65,6 @@ public class ApplicationService {
     // dupe existing tags to a mutable hashmap
     HashMap<String, String> tags = new HashMap<>(mrgResource.tags());
     tags.put(tag, value);
-    crlService.updateTagsForResource(tenantId, subscriptionId, managedResourceGroupId, tags);
+    crlService.updateTagsForResource(tenantId, subscriptionId, mrgResource.id(), tags);
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -20,13 +20,15 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
     var mrgId = "fake_mrg_id";
     var crlService = mock(CrlService.class);
     var resourceGroup = mock(ResourceGroup.class);
+    var resourceGroupId = UUID.randomUUID().toString();
+    when(resourceGroup.id()).thenReturn(resourceGroupId);
     when(crlService.getResourceGroup(tenantId, subId, mrgId)).thenReturn(resourceGroup);
     var applicationService = new ApplicationService(crlService);
 
     applicationService.addTagToMrg(tenantId, subId, mrgId, "fake_tag", "fake_value");
 
     verify(crlService)
-        .updateTagsForResource(tenantId, subId, mrgId, Map.of("fake_tag", "fake_value"));
+        .updateTagsForResource(tenantId, subId, resourceGroupId, Map.of("fake_tag", "fake_value"));
   }
 
   @Test


### PR DESCRIPTION
The previous PR was using the MRG ID, not the "fully qualified" mrg ID which is required when setting tags. 

That is, we need to use `/subscriptions/15fa50d6-105b-4eb2-8a07-a53ac7c142d9/resourceGroups/mrg-terra-dev-previ-20220921134324` vs. `mrg-terra-dev-previ-20220921134324` when setting tags via the `TagOperations` api. 