### PR TITLE
WOR-546 ignore offers from wrong publishers

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
@@ -27,6 +27,7 @@ public record AzureConfiguration(
    */
   public static class AzureApplicationOffer {
     private String name;
+    private String publisher;
     private String authorizedUserKey;
 
     public String getName() {
@@ -35,6 +36,14 @@ public record AzureConfiguration(
 
     public void setName(String name) {
       this.name = name;
+    }
+
+    public String getPublisher() {
+      return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+      this.publisher = publisher;
     }
 
     /**

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -95,7 +95,12 @@ public class AzureService {
     }
 
     var maybeOffer =
-        azureAppOffers.stream().filter(o -> o.getName().equals(app.plan().product())).findFirst();
+        azureAppOffers.stream()
+            .filter(
+                o ->
+                    o.getName().equals(app.plan().product())
+                        && o.getPublisher().equals(app.plan().publisher()))
+            .findFirst();
     if (maybeOffer.isEmpty()) {
       logger.debug(
           "App deployment is not a deployment of a well-known Terra offer, ignoring [mrg_id={}]",

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -93,6 +93,7 @@ profile:
 
     application-offers:
       - name: terra-dev-preview
+        publisher: thebroadinstituteinc1615909626976
         authorized-user-key: authorizedTerraUser
 
     required-providers:

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -33,9 +33,11 @@ public class AzureServiceUnitTest extends BaseUnitTest {
             .setToken("token")
             .build();
     var offerName = "known_terra_offer";
+    var offerPublisher = "known_terra_publisher";
 
     var authedTerraApp = mock(Application.class);
-    when(authedTerraApp.plan()).thenReturn(new Plan().withProduct(offerName));
+    when(authedTerraApp.plan())
+        .thenReturn(new Plan().withProduct(offerName).withPublisher(offerPublisher));
     when(authedTerraApp.parameters())
         .thenReturn(
             Map.of(
@@ -45,18 +47,32 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     when(authedTerraApp.name()).thenReturn("fake_app_1");
 
     var unauthedTerraApp = mock(Application.class);
-    when(unauthedTerraApp.plan()).thenReturn(new Plan().withProduct(offerName));
+    when(unauthedTerraApp.plan())
+        .thenReturn(new Plan().withProduct(offerName).withPublisher(offerPublisher));
     when(unauthedTerraApp.parameters())
         .thenReturn(Map.of("authorizedTerraUser", Map.of("value", "other@example.com")));
     when(unauthedTerraApp.managedResourceGroupId()).thenReturn("mrg_fake2");
     when(unauthedTerraApp.name()).thenReturn("fake_app_2");
 
     var otherNonTerraApp = mock(Application.class);
-    when(otherNonTerraApp.plan()).thenReturn(new Plan().withProduct("other_offer"));
+    when(otherNonTerraApp.plan())
+        .thenReturn(new Plan().withProduct("other_offer").withPublisher(offerPublisher));
     when(otherNonTerraApp.managedResourceGroupId()).thenReturn("mrg_fake3");
     when(otherNonTerraApp.name()).thenReturn("fake_app_3");
 
-    var appsList = Stream.of(authedTerraApp, unauthedTerraApp, otherNonTerraApp);
+    var differentPublisherApp = mock(Application.class);
+    when(differentPublisherApp.plan())
+        .thenReturn(new Plan().withProduct(offerName).withPublisher("other_publisher"));
+    when(differentPublisherApp.parameters())
+        .thenReturn(
+            Map.of(
+                "authorizedTerraUser",
+                Map.of("value", String.format("%s,other@example.com", authedUserEmail))));
+    when(differentPublisherApp.managedResourceGroupId()).thenReturn("mrg_fake1");
+    when(differentPublisherApp.name()).thenReturn("fake_app_1");
+
+    var appsList =
+        Stream.of(authedTerraApp, unauthedTerraApp, otherNonTerraApp, differentPublisherApp);
     var appService = mock(ApplicationService.class);
     var tenantId = UUID.randomUUID();
     when(appService.getApplicationsForSubscription(eq(subId))).thenReturn(appsList);
@@ -66,6 +82,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
     offer.setName(offerName);
+    offer.setPublisher(offerPublisher);
     offer.setAuthorizedUserKey("authorizedTerraUser");
     var offers = Set.of(offer);
     var azureService =
@@ -97,11 +114,13 @@ public class AzureServiceUnitTest extends BaseUnitTest {
             .setToken("token")
             .build();
     var offerName = "known_terra_offer";
+    var offerPublisher = "known_terra_publisher";
 
     var crlService = mock(CrlService.class);
 
     var authedTerraApp = mock(Application.class);
-    when(authedTerraApp.plan()).thenReturn(new Plan().withProduct(offerName));
+    when(authedTerraApp.plan())
+        .thenReturn(new Plan().withProduct(offerName).withPublisher(offerPublisher));
     when(authedTerraApp.parameters())
         .thenReturn(
             Map.of(
@@ -117,6 +136,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
     offer.setName(offerName);
+    offer.setPublisher(offerPublisher);
     offer.setAuthorizedUserKey("authorizedTerraUser");
     var offers = Set.of(offer);
     var azureService =


### PR DESCRIPTION
I was wearing my hacker hat this weekend (alright, I usually wear it) and realized that I don't think we are picky enough in the Azure app deployments we trust. Anybody could create an offer and name it `terra-dev`. This PR adds another restriction that an Azure app deployment must be from a configured publisher.

https://broadworkbench.atlassian.net/browse/WOR-546