### PR TITLE
[WOR-551] Add azure controller test

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/GlobalExceptionHandler.java
@@ -5,7 +5,11 @@ import bio.terra.profile.model.ErrorReport;
 import io.sentry.Sentry;
 import java.util.List;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 /**
  * This module provides a top-level exception handler for controllers. All exceptions that rise
@@ -20,5 +24,18 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
       Sentry.captureException(ex);
     }
     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()).causes(causes);
+  }
+
+  @ExceptionHandler({
+    MethodArgumentTypeMismatchException.class,
+    MissingServletRequestParameterException.class
+  })
+  public ResponseEntity<ErrorReport> validationExceptionHandler(Exception ex) {
+    var errorReport =
+        new ErrorReport()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .message("Invalid request " + ex.getClass().getSimpleName());
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorReport);
   }
 }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -244,6 +244,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AzureManagedAppsResponseModel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':

--- a/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
@@ -1,0 +1,75 @@
+package bio.terra.profile.app.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.profile.common.BaseSpringUnitTest;
+import bio.terra.profile.service.azure.AzureService;
+import bio.terra.profile.service.iam.SamService;
+import java.util.UUID;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+public class AzureApiControllerTest extends BaseSpringUnitTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockBean SamService samService;
+    @MockBean AzureService azureService;
+    AuthenticatedUserRequest userRequest =
+            AuthenticatedUserRequest.builder()
+                    .setEmail("example@example.com")
+                    .setSubjectId("fake_sub")
+                    .setToken("fake_token")
+                    .build();
+
+    @BeforeEach
+    void setup() throws Exception {
+        when(samService.getUserStatusInfo(eq(userRequest.getToken())))
+                .thenReturn(
+                        new UserStatusInfo()
+                                .userSubjectId(userRequest.getSubjectId())
+                                .userEmail(userRequest.getEmail())
+                                .enabled(true));
+    }
+
+    @Test
+    void getManagedApps_returnsOk() throws Exception {
+        var subId = UUID.randomUUID();
+        mockMvc
+                .perform(
+                        get("/api/azure/v1/managedApps")
+                                .queryParam("azureSubscriptionId", subId.toString())
+                                .header("Authorization", "Bearer " + userRequest.getToken()))
+                .andExpect(status().is(HttpStatus.OK.value()));
+    }
+
+    @Test
+    void getManagedApps_returnsBadRequestWithNoUUID() throws Exception {
+        mockMvc
+                .perform(
+                        get("/api/azure/v1/managedApps")
+                                .header("Authorization", "Bearer " + userRequest.getToken()))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void getManagedApps_returnsBadRequestWithBadUUID() throws Exception {
+        mockMvc
+                .perform(
+                        get("/api/azure/v1/managedApps")
+                                .queryParam("azureSubscriptionId", "baduuid")
+                                .header("Authorization", "Bearer " + userRequest.getToken()))
+                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    }
+}

--- a/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
@@ -71,6 +71,5 @@ public class AzureApiControllerTest extends BaseSpringUnitTest {
                 .queryParam("azureSubscriptionId", "baduuid")
                 .header("Authorization", "Bearer " + userRequest.getToken()))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    assert (false);
   }
 }

--- a/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
@@ -71,5 +71,6 @@ public class AzureApiControllerTest extends BaseSpringUnitTest {
                 .queryParam("azureSubscriptionId", "baduuid")
                 .header("Authorization", "Bearer " + userRequest.getToken()))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+    assert (false);
   }
 }

--- a/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
@@ -22,54 +22,54 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 public class AzureApiControllerTest extends BaseSpringUnitTest {
 
-    @Autowired MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @MockBean SamService samService;
-    @MockBean AzureService azureService;
-    AuthenticatedUserRequest userRequest =
-            AuthenticatedUserRequest.builder()
-                    .setEmail("example@example.com")
-                    .setSubjectId("fake_sub")
-                    .setToken("fake_token")
-                    .build();
+  @MockBean SamService samService;
+  @MockBean AzureService azureService;
+  private final AuthenticatedUserRequest userRequest =
+      AuthenticatedUserRequest.builder()
+          .setEmail("example@example.com")
+          .setSubjectId("fake_sub")
+          .setToken("fake_token")
+          .build();
 
-    @BeforeEach
-    void setup() throws Exception {
-        when(samService.getUserStatusInfo(eq(userRequest.getToken())))
-                .thenReturn(
-                        new UserStatusInfo()
-                                .userSubjectId(userRequest.getSubjectId())
-                                .userEmail(userRequest.getEmail())
-                                .enabled(true));
-    }
+  @BeforeEach
+  void setup() throws Exception {
+    when(samService.getUserStatusInfo(eq(userRequest.getToken())))
+        .thenReturn(
+            new UserStatusInfo()
+                .userSubjectId(userRequest.getSubjectId())
+                .userEmail(userRequest.getEmail())
+                .enabled(true));
+  }
 
-    @Test
-    void getManagedApps_returnsOk() throws Exception {
-        var subId = UUID.randomUUID();
-        mockMvc
-                .perform(
-                        get("/api/azure/v1/managedApps")
-                                .queryParam("azureSubscriptionId", subId.toString())
-                                .header("Authorization", "Bearer " + userRequest.getToken()))
-                .andExpect(status().is(HttpStatus.OK.value()));
-    }
+  @Test
+  void getManagedApps_returnsOk() throws Exception {
+    var subId = UUID.randomUUID();
+    mockMvc
+        .perform(
+            get("/api/azure/v1/managedApps")
+                .queryParam("azureSubscriptionId", subId.toString())
+                .header("Authorization", "Bearer " + userRequest.getToken()))
+        .andExpect(status().is(HttpStatus.OK.value()));
+  }
 
-    @Test
-    void getManagedApps_returnsBadRequestWithNoUUID() throws Exception {
-        mockMvc
-                .perform(
-                        get("/api/azure/v1/managedApps")
-                                .header("Authorization", "Bearer " + userRequest.getToken()))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
+  @Test
+  void getManagedApps_returnsBadRequestWithNoUUID() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/azure/v1/managedApps")
+                .header("Authorization", "Bearer " + userRequest.getToken()))
+        .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+  }
 
-    @Test
-    void getManagedApps_returnsBadRequestWithBadUUID() throws Exception {
-        mockMvc
-                .perform(
-                        get("/api/azure/v1/managedApps")
-                                .queryParam("azureSubscriptionId", "baduuid")
-                                .header("Authorization", "Bearer " + userRequest.getToken()))
-                .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
-    }
+  @Test
+  void getManagedApps_returnsBadRequestWithBadUUID() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/azure/v1/managedApps")
+                .queryParam("azureSubscriptionId", "baduuid")
+                .header("Authorization", "Bearer " + userRequest.getToken()))
+        .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+  }
 }

--- a/service/src/test/java/bio/terra/profile/common/BaseUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/common/BaseUnitTest.java
@@ -4,5 +4,5 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.ActiveProfiles;
 
 @Tag("unit")
-@ActiveProfiles({"test", "unit"})
+@ActiveProfiles({"test", "unit", "human-readable-logging"})
 public class BaseUnitTest {}


### PR DESCRIPTION
While looking into smoke tests for BPM, I found that we 500 when no subscription ID is passed to the `getManagedApps` endpoint. This PR fixes that issue by adding a global exception handler to return 400 on MethodArgumentTypeMismatchException and MissingServletRequestParameterException, as well as a test for the controller.