### PR TITLE
[WOR-560] Add test for the create profile flight

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStep.java
@@ -17,15 +17,16 @@ import java.util.List;
 record CreateProfileVerifyAccountStep(
     CrlService crlService, BillingProfile profile, AuthenticatedUserRequest user) implements Step {
 
+  public static List<String> PERMISSIONS_TO_TEST = List.of("billing.resourceAssociations.create");
+
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     var billingCow = crlService.getBillingClientCow(user);
 
-    var permissionsToTest = List.of("billing.resourceAssociations.create");
     var testPermissionsRequest =
         TestIamPermissionsRequest.newBuilder()
-            .setResource(BillingAccountName.of(profile.billingAccountId().get()).toString())
-            .addAllPermissions(permissionsToTest)
+            .setResource(BillingAccountName.of(profile.getRequiredBillingAccountId()).toString())
+            .addAllPermissions(PERMISSIONS_TO_TEST)
             .build();
 
     final TestIamPermissionsResponse testPermissionsResponse;
@@ -36,7 +37,7 @@ record CreateProfileVerifyAccountStep(
     }
 
     var actualPermissions = testPermissionsResponse.getPermissionsList();
-    if (actualPermissions == null || !actualPermissions.equals(permissionsToTest)) {
+    if (actualPermissions == null || !actualPermissions.equals(PERMISSIONS_TO_TEST)) {
       var message =
           String.format(
               "The user [%s] needs access to the billing account [%s] to perform the requested operation",

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -35,7 +35,8 @@ record CreateProfileVerifyDeployedApplicationStep(
                           Objects.equals(
                                   app.getManagedResourceGroupId(),
                                   profile.getRequiredManagedResourceGroupId())
-                              && app.getSubscriptionId() == profile.getRequiredSubscriptionId())
+                              && Objects.equals(
+                                  app.getSubscriptionId(), profile.getRequiredSubscriptionId()))
                   .count()
               == 1;
     } catch (Exception e) {

--- a/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
@@ -4,6 +4,7 @@ import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.model.CreateProfileRequest;
 import bio.terra.profile.model.ProfileModel;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -97,16 +98,25 @@ public record BillingProfile(
         .createdBy(createdBy);
   }
 
+  @JsonIgnore
+  public String getRequiredBillingAccountId() {
+    return billingAccountId.orElseThrow(
+        () -> new MissingRequiredFieldsException("Missing billing account ID"));
+  }
+
+  @JsonIgnore
   public UUID getRequiredTenantId() {
     return tenantId.orElseThrow(
         () -> new MissingRequiredFieldsException("Missing azure tenant ID"));
   }
 
+  @JsonIgnore
   public UUID getRequiredSubscriptionId() {
     return subscriptionId.orElseThrow(
         () -> new MissingRequiredFieldsException("Missing azure subscription ID"));
   }
 
+  @JsonIgnore
   public String getRequiredManagedResourceGroupId() {
     return managedResourceGroupId.orElseThrow(
         () -> new MissingRequiredFieldsException("Missing azure managed resource group ID"));

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class CreateProfileFlightTest extends BaseSpringUnitTest {
+class CreateProfileFlightTest extends BaseSpringUnitTest {
 
   @Autowired ProfileService profileService;
   @Autowired AzureConfiguration azureConfiguration;
@@ -198,11 +198,6 @@ public class CreateProfileFlightTest extends BaseSpringUnitTest {
     profileService.createProfile(profile, userRequest);
 
     verify(applicationService)
-        .addTagToMrg(
-            eq(tenantId),
-            eq(subId),
-            eq(mrgId),
-            eq("terra.billingProfileId"),
-            eq(profile.id().toString()));
+        .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -1,0 +1,208 @@
+package bio.terra.profile.service.profile.flight.create;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import bio.terra.cloudres.google.billing.CloudBillingClientCow;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.profile.app.configuration.AzureConfiguration;
+import bio.terra.profile.common.BaseSpringUnitTest;
+import bio.terra.profile.model.AzureManagedAppModel;
+import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.azure.AzureService;
+import bio.terra.profile.service.crl.CrlService;
+import bio.terra.profile.service.iam.SamService;
+import bio.terra.profile.service.profile.ProfileService;
+import bio.terra.profile.service.profile.exception.InaccessibleApplicationDeploymentException;
+import bio.terra.profile.service.profile.exception.InaccessibleBillingAccountException;
+import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
+import bio.terra.profile.service.profile.model.BillingProfile;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class CreateProfileFlightTest extends BaseSpringUnitTest {
+
+  @Autowired ProfileService profileService;
+  @Autowired AzureConfiguration azureConfiguration;
+  @MockBean CrlService crlService;
+
+  @MockBean SamService samService;
+  @MockBean AzureService azureService;
+  @MockBean ApplicationService applicationService;
+
+  AuthenticatedUserRequest userRequest =
+      AuthenticatedUserRequest.builder()
+          .setToken("fake-token")
+          .setSubjectId("fake-sub")
+          .setEmail("example@example.com")
+          .build();
+
+  @Test
+  void createGcpProfileSuccess() {
+    var billingCow = mock(CloudBillingClientCow.class);
+    when(crlService.getBillingClientCow(any())).thenReturn(billingCow);
+    var iamPermissionsResponse =
+        TestIamPermissionsResponse.newBuilder()
+            .addAllPermissions(CreateProfileVerifyAccountStep.PERMISSIONS_TO_TEST)
+            .build();
+    when(billingCow.testIamPermissions(any())).thenReturn(iamPermissionsResponse);
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.GCP,
+            Optional.of("ABCDEF-1234"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            null,
+            null,
+            null);
+
+    var createdProfile = profileService.createProfile(profile, userRequest);
+
+    assertEquals(createdProfile.id(), profile.id());
+    assertEquals(createdProfile.biller(), profile.biller());
+    assertEquals(createdProfile.cloudPlatform(), profile.cloudPlatform());
+    assertEquals(createdProfile.billingAccountId().get(), profile.billingAccountId().get());
+    assertEquals(createdProfile.displayName(), profile.displayName());
+    assertNotNull(createdProfile.createdTime());
+    assertNotNull(createdProfile.lastModified());
+    assertEquals(createdProfile.createdBy(), userRequest.getEmail());
+  }
+
+  @Test
+  void createGcpProfileMissingBillingAccount() {
+    var billingCow = mock(CloudBillingClientCow.class);
+    when(crlService.getBillingClientCow(any())).thenReturn(billingCow);
+    var iamPermissionsResponse =
+        TestIamPermissionsResponse.newBuilder()
+            .addAllPermissions(CreateProfileVerifyAccountStep.PERMISSIONS_TO_TEST)
+            .build();
+    when(billingCow.testIamPermissions(any())).thenReturn(iamPermissionsResponse);
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.GCP,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            null,
+            null,
+            null);
+
+    assertThrows(
+        MissingRequiredFieldsException.class,
+        () -> profileService.createProfile(profile, userRequest));
+  }
+
+  @Test
+  void createGcpProfileInvalidPermissions() {
+    var billingCow = mock(CloudBillingClientCow.class);
+    when(crlService.getBillingClientCow(any())).thenReturn(billingCow);
+    var iamPermissionsResponse =
+        TestIamPermissionsResponse.newBuilder()
+            .addAllPermissions(List.of("billing:wrong", "billing:fake"))
+            .build();
+    when(billingCow.testIamPermissions(any())).thenReturn(iamPermissionsResponse);
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.GCP,
+            Optional.of("ABCDEF-1234"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            null,
+            null,
+            null);
+
+    assertThrows(
+        InaccessibleBillingAccountException.class,
+        () -> profileService.createProfile(profile, userRequest));
+  }
+
+  @Test
+  void createAzureProfileInaccessibleAppDeployment() {
+    when(azureService.getAuthorizedManagedAppDeployments(any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.empty(),
+            Optional.of(UUID.randomUUID()),
+            Optional.of(UUID.randomUUID()),
+            Optional.of("fake-mrg"),
+            null,
+            null,
+            null);
+
+    assertThrows(
+        InaccessibleApplicationDeploymentException.class,
+        () -> profileService.createProfile(profile, userRequest));
+  }
+
+  @Test
+  void createAzureProfileSuccess() {
+    var subId = UUID.randomUUID();
+    var tenantId = UUID.randomUUID();
+    var mrgId = "fake-mrg";
+
+    when(azureService.getAuthorizedManagedAppDeployments(any(), any()))
+        .thenReturn(
+            Collections.singletonList(
+                new AzureManagedAppModel()
+                    .tenantId(tenantId)
+                    .subscriptionId(subId)
+                    .managedResourceGroupId(mrgId)));
+    when(azureService.getRegisteredProviderNamespacesForSubscription(any(), any()))
+        .thenReturn(azureConfiguration.getRequiredProviders());
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.empty(),
+            Optional.of(tenantId),
+            Optional.of(subId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+
+    profileService.createProfile(profile, userRequest);
+
+    verify(applicationService)
+        .addTagToMrg(
+            eq(tenantId),
+            eq(subId),
+            eq(mrgId),
+            eq("terra.billingProfileId"),
+            eq(profile.id().toString()));
+  }
+}

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStepTest.java
@@ -69,7 +69,7 @@ public class CreateProfileVerifyAccountStepTest extends BaseSpringUnitTest {
     when(billingClientCow.testIamPermissions(captor.capture()))
         .thenReturn(
             TestIamPermissionsResponse.newBuilder()
-                .addAllPermissions(List.of("billing.resourceAssociations.create"))
+                .addAllPermissions(CreateProfileVerifyAccountStep.PERMISSIONS_TO_TEST)
                 .build());
 
     var result = step.doStep(flightContext);
@@ -77,7 +77,7 @@ public class CreateProfileVerifyAccountStepTest extends BaseSpringUnitTest {
     assertEquals(
         "billingAccounts/" + profile.billingAccountId().get(), captor.getValue().getResource());
     assertEquals(
-        List.of("billing.resourceAssociations.create"), captor.getValue().getPermissionsList());
+        CreateProfileVerifyAccountStep.PERMISSIONS_TO_TEST, captor.getValue().getPermissionsList());
     assertEquals(StepResult.getStepResultSuccess(), result);
   }
 
@@ -95,6 +95,6 @@ public class CreateProfileVerifyAccountStepTest extends BaseSpringUnitTest {
     assertEquals(
         "billingAccounts/" + profile.billingAccountId().get(), captor.getValue().getResource());
     assertEquals(
-        List.of("billing.resourceAssociations.create"), captor.getValue().getPermissionsList());
+        CreateProfileVerifyAccountStep.PERMISSIONS_TO_TEST, captor.getValue().getPermissionsList());
   }
 }


### PR DESCRIPTION
This [sentry](https://sentry.io/organizations/broad-institute/issues/3653521049/?project=6608698&query=is%3Aunresolved) is caused by the [PR I merged here](https://github.com/DataBiosphere/terra-billing-profile-manager/pull/45/files). Specifically, the addition of the `getRequiredFoo` methods means Jackson will attempt to serialize those fields even for GCP profiles. 

We are lacking coverage for the `CreateProfileFlight`, so I've added that which gives us regression coverage on further serialization issues with this class and that flight in general. 
 