### PR TITLE
[WOR-496] Fix version endpoint

### DIFF
--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -39,8 +39,8 @@ compileJava.dependsOn generateSwaggerCode
 // see https://github.com/n0mer/gradle-git-properties
 gitProperties {
     keys = []
-    customProperty('catalog.version.gitTag', { it.describe(tags: true) })
-    customProperty('catalog.version.gitHash', { it.head().abbreviatedId })
-    customProperty('catalog.version.github', { "https://github.com/DataBiosphere/terra-billing-profile-manager/tree/${it.describe(tags: true)}" })
-    customProperty('catalog.version.build', version)
+    customProperty('bpm.version.gitTag', { it.describe(tags: true) })
+    customProperty('bpm.version.gitHash', { it.head().abbreviatedId })
+    customProperty('bpm.version.github', { "https://github.com/DataBiosphere/terra-billing-profile-manager/tree/${it.describe(tags: true)}" })
+    customProperty('bpm.version.build', version)
 }

--- a/service/src/main/java/bio/terra/profile/app/configuration/VersionConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/VersionConfiguration.java
@@ -5,12 +5,14 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 
-/** Read from the version.properties file auto-generated at build time */
+/** Read from the git.properties file auto-generated at build time */
 @Configuration
-@ConfigurationProperties(prefix = "version")
+@ConfigurationProperties(prefix = "bpm.version")
+@PropertySource("classpath:git.properties")
 public class VersionConfiguration implements InitializingBean {
   private final ConfigurableEnvironment configurableEnvironment;
   private String gitHash;


### PR DESCRIPTION
We are correctly building a version information file but are not looking in the correct place for it at runtime. Test output:

```
 » curl -X 'GET' \                                                                       (gke_broad-dsde-qa_us-central1-a_terra-qa-bees/default)
  'http://localhost:8080/version' \
  -H 'accept: */*'
{"gitTag":"0.1.35","gitHash":"a4b29d9","github":"https://github.com/DataBiosphere/terra-billing-profile-manager/commit/a4b29d9","build":"0.1.35-SNAPSHOT"}%    ```
