### PR TITLE
[WOR-156] Limit one billing profile per Azure managed app

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -31,11 +31,11 @@ public class AzureApiController implements AzureApi {
 
   @Override
   public ResponseEntity<AzureManagedAppsResponseModel> getManagedAppDeployments(
-      UUID azureSubscriptionId,
-      Boolean includeAssignedApplications) {
+      UUID azureSubscriptionId, Boolean includeAssignedApplications) {
     final AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
     var managedApps =
-        this.azureService.getAuthorizedManagedAppDeployments(azureSubscriptionId, includeAssignedApplications, userRequest);
+        this.azureService.getAuthorizedManagedAppDeployments(
+            azureSubscriptionId, includeAssignedApplications, userRequest);
 
     return new ResponseEntity<>(
         new AzureManagedAppsResponseModel().managedApps(managedApps), HttpStatus.OK);

--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -31,10 +31,11 @@ public class AzureApiController implements AzureApi {
 
   @Override
   public ResponseEntity<AzureManagedAppsResponseModel> getManagedAppDeployments(
-      UUID azureSubscriptionId) {
+      UUID azureSubscriptionId,
+      Boolean includeAssignedApplications) {
     final AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
     var managedApps =
-        this.azureService.getAuthorizedManagedAppDeployments(azureSubscriptionId, userRequest);
+        this.azureService.getAuthorizedManagedAppDeployments(azureSubscriptionId, includeAssignedApplications, userRequest);
 
     return new ResponseEntity<>(
         new AzureManagedAppsResponseModel().managedApps(managedApps), HttpStatus.OK);

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -97,7 +97,7 @@ public class ProfileDao {
           keyHolder.getString("created_by"));
     } catch (DuplicateKeyException ex) {
       if (ex.getMessage()
-          .contains("billing_profile_tenant_id_subscription_id_managed_resource__key")) {
+          .contains("billing_profile_subscription_id_managed_resource_group_id_key")) {
         throw new DuplicateManagedApplicationException("Managed application already in use.");
       } else {
         throw ex;
@@ -121,14 +121,13 @@ public class ProfileDao {
     return jdbcTemplate.query(SQL_LIST, params, new BillingProfileMapper());
   }
 
-  public List<String> listManagedResourceGroupsInSubscription(UUID tenantId, UUID subscriptionId) {
+  public List<String> listManagedResourceGroupsInSubscription(UUID subscriptionId) {
     var params =
         new MapSqlParameterSource()
-            .addValue("tenantId", tenantId)
             .addValue("subscriptionId", subscriptionId);
     return jdbcTemplate.queryForList(
         "SELECT managed_resource_group_id from billing_profile"
-            + " where tenant_id = :tenantId and subscription_id = :subscriptionId",
+            + " where subscription_id = :subscriptionId",
         params,
         String.class);
   }

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -4,7 +4,6 @@ import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.model.CloudPlatform;
-import bio.terra.profile.service.azure.model.ManagedAppCoordinates;
 import bio.terra.profile.service.profile.exception.DuplicateManagedApplicationException;
 import bio.terra.profile.service.profile.exception.ProfileInUseException;
 import bio.terra.profile.service.profile.exception.ProfileNotFoundException;
@@ -29,6 +28,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class ProfileDao {
+
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   // SQL select string constants
@@ -85,20 +85,21 @@ public class ProfileDao {
       jdbcTemplate.update(sql, params, keyHolder);
 
       return new BillingProfile(
-              profile.id(),
-              profile.displayName(),
-              profile.description(),
-              profile.biller(),
-              profile.cloudPlatform(),
-              profile.billingAccountId(),
-              profile.tenantId(),
-              profile.subscriptionId(),
-              profile.managedResourceGroupId(),
-              keyHolder.getInstant("created_date"),
-              keyHolder.getInstant("last_modified"),
-              keyHolder.getString("created_by"));
+          profile.id(),
+          profile.displayName(),
+          profile.description(),
+          profile.biller(),
+          profile.cloudPlatform(),
+          profile.billingAccountId(),
+          profile.tenantId(),
+          profile.subscriptionId(),
+          profile.managedResourceGroupId(),
+          keyHolder.getInstant("created_date"),
+          keyHolder.getInstant("last_modified"),
+          keyHolder.getString("created_by"));
     } catch (DuplicateKeyException ex) {
-      if (ex.getMessage().contains("billing_profile_tenant_id_subscription_id_managed_resource__key")) {
+      if (ex.getMessage()
+          .contains("billing_profile_tenant_id_subscription_id_managed_resource__key")) {
         throw new DuplicateManagedApplicationException("Managed application already in use.");
       } else {
         throw ex;
@@ -123,8 +124,12 @@ public class ProfileDao {
   }
 
   public List<String> listAssignedManagedApps(UUID tenantId, UUID subscriptionId) {
-    var params = new MapSqlParameterSource().addValue("tenantId", tenantId).addValue("subscriptionId", subscriptionId);
-    return jdbcTemplate.queryForList("SELECT managed_resource_group_id from billing_profile where tenant_id = :tenantId and subscription_id = :subscriptionId", params, String.class);
+    var params = new MapSqlParameterSource().addValue("tenantId", tenantId)
+        .addValue("subscriptionId", subscriptionId);
+    return jdbcTemplate.queryForList(
+        "SELECT managed_resource_group_id from billing_profile" +
+            " where tenant_id = :tenantId and subscription_id = :subscriptionId",
+        params, String.class);
   }
 
   @ReadTransaction
@@ -153,6 +158,7 @@ public class ProfileDao {
   }
 
   private static class BillingProfileMapper implements RowMapper<BillingProfile> {
+
     public BillingProfile mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new BillingProfile(
           rs.getObject("id", UUID.class),

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
@@ -123,12 +122,15 @@ public class ProfileDao {
   }
 
   public List<String> listManagedResourceGroupsInSubscription(UUID tenantId, UUID subscriptionId) {
-    var params = new MapSqlParameterSource().addValue("tenantId", tenantId)
-        .addValue("subscriptionId", subscriptionId);
+    var params =
+        new MapSqlParameterSource()
+            .addValue("tenantId", tenantId)
+            .addValue("subscriptionId", subscriptionId);
     return jdbcTemplate.queryForList(
-        "SELECT managed_resource_group_id from billing_profile" +
-            " where tenant_id = :tenantId and subscription_id = :subscriptionId",
-        params, String.class);
+        "SELECT managed_resource_group_id from billing_profile"
+            + " where tenant_id = :tenantId and subscription_id = :subscriptionId",
+        params,
+        String.class);
   }
 
   @ReadTransaction

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -4,6 +4,7 @@ import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.service.azure.model.ManagedAppCoordinates;
 import bio.terra.profile.service.profile.exception.DuplicateManagedApplicationException;
 import bio.terra.profile.service.profile.exception.ProfileInUseException;
 import bio.terra.profile.service.profile.exception.ProfileNotFoundException;
@@ -15,6 +16,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.google.api.Billing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
@@ -117,6 +120,11 @@ public class ProfileDao {
             .addValue("offset", offset)
             .addValue("limit", limit);
     return jdbcTemplate.query(SQL_LIST, params, new BillingProfileMapper());
+  }
+
+  public List<String> listAssignedManagedApps(UUID tenantId, UUID subscriptionId) {
+    var params = new MapSqlParameterSource().addValue("tenantId", tenantId).addValue("subscriptionId", subscriptionId);
+    return jdbcTemplate.queryForList("SELECT managed_resource_group_id from billing_profile where tenant_id = :tenantId and subscription_id = :subscriptionId", params, String.class);
   }
 
   @ReadTransaction

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import com.google.api.Billing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
@@ -123,7 +122,7 @@ public class ProfileDao {
     return jdbcTemplate.query(SQL_LIST, params, new BillingProfileMapper());
   }
 
-  public List<String> listAssignedManagedApps(UUID tenantId, UUID subscriptionId) {
+  public List<String> listManagedResourceGroupsInSubscription(UUID tenantId, UUID subscriptionId) {
     var params = new MapSqlParameterSource().addValue("tenantId", tenantId)
         .addValue("subscriptionId", subscriptionId);
     return jdbcTemplate.queryForList(

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -122,9 +122,7 @@ public class ProfileDao {
   }
 
   public List<String> listManagedResourceGroupsInSubscription(UUID subscriptionId) {
-    var params =
-        new MapSqlParameterSource()
-            .addValue("subscriptionId", subscriptionId);
+    var params = new MapSqlParameterSource().addValue("subscriptionId", subscriptionId);
     return jdbcTemplate.queryForList(
         "SELECT managed_resource_group_id from billing_profile"
             + " where subscription_id = :subscriptionId",

--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -96,8 +96,9 @@ public class ProfileDao {
           keyHolder.getInstant("last_modified"),
           keyHolder.getString("created_by"));
     } catch (DuplicateKeyException ex) {
-      if (ex.getMessage()
-          .contains("billing_profile_subscription_id_managed_resource_group_id_key")) {
+      if (ex.getMessage() != null
+          && ex.getMessage()
+              .contains("billing_profile_subscription_id_managed_resource_group_id_key")) {
         throw new DuplicateManagedApplicationException("Managed application already in use.");
       } else {
         throw ex;

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -58,16 +57,16 @@ public class AzureService {
 
     Stream<Application> applications = appService.getApplicationsForSubscription(subscriptionId);
 
-    List<String> assignedManagedApplications;
+    List<String> assignedManagedResourceGroups;
     if (includeAssignedApplications) {
-      assignedManagedApplications = Collections.emptyList();
+      assignedManagedResourceGroups = Collections.emptyList();
     } else {
-      assignedManagedApplications = profileDao.listAssignedManagedApps(tenantId, subscriptionId);
+      assignedManagedResourceGroups = profileDao.listManagedResourceGroupsInSubscription(tenantId, subscriptionId);
     }
 
     return applications
         .filter(app -> isAuthedTerraManagedApp(userRequest, app))
-        .filter(app -> !assignedManagedApplications.contains(
+        .filter(app -> !assignedManagedResourceGroups.contains(
             normalizeManagedResourceGroupId(app.managedResourceGroupId())))
         .map(
             app ->

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -4,7 +4,6 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.AzureManagedAppModel;
-import bio.terra.profile.service.azure.model.ManagedAppCoordinates;
 import bio.terra.profile.service.crl.CrlService;
 import com.azure.resourcemanager.managedapplications.models.Application;
 import com.azure.resourcemanager.resources.models.Provider;
@@ -24,6 +23,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class AzureService {
+
   private static final Logger logger = LoggerFactory.getLogger(AzureService.class);
 
   private final ApplicationService appService;
@@ -33,7 +33,10 @@ public class AzureService {
 
   @Autowired
   public AzureService(
-          CrlService crlService, ApplicationService appService, AzureConfiguration azureConfiguration, ProfileDao profileDao) {
+      CrlService crlService,
+      ApplicationService appService,
+      AzureConfiguration azureConfiguration,
+      ProfileDao profileDao) {
     this.crlService = crlService;
     this.appService = appService;
     this.azureAppOffers = azureConfiguration.getApplicationOffers();
@@ -44,16 +47,16 @@ public class AzureService {
    * Gets the Azure managed applications the user has access to in the given subscription.
    *
    * @param subscriptionId Azure subscription ID that will be checked for managed applications
-   * @param userRequest Authorized user request
+   * @param userRequest    Authorized user request
    * @return List of Terra Azure managed applications the user has access to
    */
   public List<AzureManagedAppModel> getAuthorizedManagedAppDeployments(
-      UUID subscriptionId, Boolean includeAssignedApplications, AuthenticatedUserRequest userRequest) {
+      UUID subscriptionId,
+      Boolean includeAssignedApplications,
+      AuthenticatedUserRequest userRequest) {
     var tenantId = appService.getTenantForSubscription(subscriptionId);
 
     Stream<Application> applications = appService.getApplicationsForSubscription(subscriptionId);
-
-    // todo: do we need to check if the user has access to a billing profile that is using the managed app before we filter it out? or good to just filter any out
 
     List<String> assignedManagedApplications;
     if (includeAssignedApplications) {
@@ -64,7 +67,8 @@ public class AzureService {
 
     return applications
         .filter(app -> isAuthedTerraManagedApp(userRequest, app))
-        .filter(app -> !assignedManagedApplications.contains(normalizeManagedResourceGroupId(app.managedResourceGroupId())))
+        .filter(app -> !assignedManagedApplications.contains(
+            normalizeManagedResourceGroupId(app.managedResourceGroupId())))
         .map(
             app ->
                 new AzureManagedAppModel()
@@ -81,7 +85,7 @@ public class AzureService {
    * Gets the resource provider namespaces in a subscription that are in either the "Registered" or
    * "Registering" state.
    *
-   * @param tenantId Azure tenant ID associated with the given subscription.
+   * @param tenantId       Azure tenant ID associated with the given subscription.
    * @param subscriptionId Azure subscription ID to be checked for providers
    * @return Set of registered or registering resource providers namespaces.
    */

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -46,7 +46,7 @@ public class AzureService {
    * Gets the Azure managed applications the user has access to in the given subscription.
    *
    * @param subscriptionId Azure subscription ID that will be checked for managed applications
-   * @param userRequest    Authorized user request
+   * @param userRequest Authorized user request
    * @return List of Terra Azure managed applications the user has access to
    */
   public List<AzureManagedAppModel> getAuthorizedManagedAppDeployments(
@@ -61,13 +61,16 @@ public class AzureService {
     if (includeAssignedApplications) {
       assignedManagedResourceGroups = Collections.emptyList();
     } else {
-      assignedManagedResourceGroups = profileDao.listManagedResourceGroupsInSubscription(tenantId, subscriptionId);
+      assignedManagedResourceGroups =
+          profileDao.listManagedResourceGroupsInSubscription(tenantId, subscriptionId);
     }
 
     return applications
         .filter(app -> isAuthedTerraManagedApp(userRequest, app))
-        .filter(app -> !assignedManagedResourceGroups.contains(
-            normalizeManagedResourceGroupId(app.managedResourceGroupId())))
+        .filter(
+            app ->
+                !assignedManagedResourceGroups.contains(
+                    normalizeManagedResourceGroupId(app.managedResourceGroupId())))
         .map(
             app ->
                 new AzureManagedAppModel()
@@ -84,7 +87,7 @@ public class AzureService {
    * Gets the resource provider namespaces in a subscription that are in either the "Registered" or
    * "Registering" state.
    *
-   * @param tenantId       Azure tenant ID associated with the given subscription.
+   * @param tenantId Azure tenant ID associated with the given subscription.
    * @param subscriptionId Azure subscription ID to be checked for providers
    * @return Set of registered or registering resource providers namespaces.
    */

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -8,7 +8,6 @@ import bio.terra.profile.service.crl.CrlService;
 import com.azure.resourcemanager.managedapplications.models.Application;
 import com.azure.resourcemanager.resources.models.Provider;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,7 +57,7 @@ public class AzureService {
     Stream<Application> applications = appService.getApplicationsForSubscription(subscriptionId);
 
     List<String> assignedManagedResourceGroups =
-          profileDao.listManagedResourceGroupsInSubscription(subscriptionId);
+        profileDao.listManagedResourceGroupsInSubscription(subscriptionId);
 
     return applications
         .filter(app -> isAuthedTerraManagedApp(userRequest, app))
@@ -70,10 +69,10 @@ public class AzureService {
                     .managedResourceGroupId(
                         normalizeManagedResourceGroupId(app.managedResourceGroupId()))
                     .tenantId(tenantId)
-                    .assigned(assignedManagedResourceGroups.contains(
-                        normalizeManagedResourceGroupId(app.managedResourceGroupId()))))
-        .filter(app ->
-            includeAssignedApplications || !app.isAssigned())
+                    .assigned(
+                        assignedManagedResourceGroups.contains(
+                            normalizeManagedResourceGroupId(app.managedResourceGroupId()))))
+        .filter(app -> includeAssignedApplications || !app.isAssigned())
         .distinct()
         .toList();
   }

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -62,7 +62,7 @@ public class AzureService {
       assignedManagedResourceGroups = Collections.emptyList();
     } else {
       assignedManagedResourceGroups =
-          profileDao.listManagedResourceGroupsInSubscription(tenantId, subscriptionId);
+          profileDao.listManagedResourceGroupsInSubscription(subscriptionId);
     }
 
     return applications

--- a/service/src/main/java/bio/terra/profile/service/azure/model/ManagedAppCoordinates.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/model/ManagedAppCoordinates.java
@@ -1,0 +1,9 @@
+package bio.terra.profile.service.azure.model;
+
+import java.util.UUID;
+
+public record ManagedAppCoordinates(
+        UUID tenantId,
+        UUID subscriptionId
+) {
+}

--- a/service/src/main/java/bio/terra/profile/service/azure/model/ManagedAppCoordinates.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/model/ManagedAppCoordinates.java
@@ -1,9 +1,0 @@
-package bio.terra.profile.service.azure.model;
-
-import java.util.UUID;
-
-public record ManagedAppCoordinates(
-        UUID tenantId,
-        UUID subscriptionId
-) {
-}

--- a/service/src/main/java/bio/terra/profile/service/profile/exception/DuplicateManagedApplicationException.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/exception/DuplicateManagedApplicationException.java
@@ -1,0 +1,17 @@
+package bio.terra.profile.service.profile.exception;
+
+import bio.terra.common.exception.ConflictException;
+
+public class DuplicateManagedApplicationException extends ConflictException {
+    public DuplicateManagedApplicationException(String message) {
+        super(message);
+    }
+
+    public DuplicateManagedApplicationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DuplicateManagedApplicationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/service/src/main/java/bio/terra/profile/service/profile/exception/DuplicateManagedApplicationException.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/exception/DuplicateManagedApplicationException.java
@@ -3,15 +3,15 @@ package bio.terra.profile.service.profile.exception;
 import bio.terra.common.exception.ConflictException;
 
 public class DuplicateManagedApplicationException extends ConflictException {
-    public DuplicateManagedApplicationException(String message) {
-        super(message);
-    }
+  public DuplicateManagedApplicationException(String message) {
+    super(message);
+  }
 
-    public DuplicateManagedApplicationException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public DuplicateManagedApplicationException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-    public DuplicateManagedApplicationException(Throwable cause) {
-        super(cause);
-    }
+  public DuplicateManagedApplicationException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -27,7 +27,7 @@ record CreateProfileVerifyDeployedApplicationStep(
     try {
       var apps =
           azureService.getAuthorizedManagedAppDeployments(
-              profile.getRequiredSubscriptionId(), user);
+              profile.getRequiredSubscriptionId(), true, user);
       canAccess =
           apps.stream()
                   .filter(

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -233,6 +233,7 @@ paths:
     get:
       parameters:
         - $ref: '#/components/parameters/AzureSubscriptionId'
+        - $ref: '#/components/parameters/IncludeAssignedApplications'
       summary: Gets the Azure managed app deployments the caller has access to
       operationId: getManagedAppDeployments
       tags:
@@ -263,6 +264,15 @@ components:
       schema:
         type: string
         format: uuid
+
+    IncludeAssignedApplications:
+      name: includeAssignedApplications
+      in: query
+      description: Defaults to false. When set to true, managed applications that are already assigned to billing profiles will be returned.
+      required: false
+      schema:
+        type: boolean
+        default: false
 
     ProfileId:
       name: profileId

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -424,6 +424,7 @@ components:
         - managedResourceGroupId
         - subscriptionId
         - tenantId
+        - assigned
       properties:
         applicationDeploymentName:
           type: string
@@ -439,6 +440,9 @@ components:
           type: string
           format: uuid
           description: Azure tenant ID containing the Terra app deployment
+        assigned:
+          type: boolean
+          description: True if this managed app is assigned to a Terra billing profile
 
     SamPolicyModel:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -442,7 +442,7 @@ components:
           description: Azure tenant ID containing the Terra app deployment
         assigned:
           type: boolean
-          description: True if this managed app is assigned to a Terra billing profile
+          description: True if this managed app is assigned to a billing profile
 
     SamPolicyModel:
       type: object

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -32,7 +32,7 @@ env:
 # contains the configuration of the BPM test application. We can use that application in our
 # integration testing to make sure the application code paths are working. However, we do not
 # want it to appear in production environments.
-spring.config.import: optional:file:service/build/resources/main/generated/local-properties.yaml
+spring.config.import: optional:file:build/resources/main/generated/local-properties.yaml
 
 logging.pattern.level: '%X{requestId} %5p'
 

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -14,4 +14,5 @@
     <include file="changesets/20220117_billing_profiles.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220713_billing_profiles_last_modified.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20220803_billing_profiles_managed_resource_group_id.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221011_unique_managed_application.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20221011_unique_managed_application.yaml
+++ b/service/src/main/resources/db/changesets/20221011_unique_managed_application.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: unique_managed_application
+      author: mtalbott
+      changes:
+        - addUniqueConstraint:
+            constraint_name: unique_managed_application
+            tableName: billing_profile
+            columnNames: tenant_id, subscription_id, managed_resource_group_id

--- a/service/src/main/resources/db/changesets/20221011_unique_managed_application.yaml
+++ b/service/src/main/resources/db/changesets/20221011_unique_managed_application.yaml
@@ -6,4 +6,4 @@ databaseChangeLog:
         - addUniqueConstraint:
             constraint_name: unique_managed_application
             tableName: billing_profile
-            columnNames: tenant_id, subscription_id, managed_resource_group_id
+            columnNames: subscription_id, managed_resource_group_id

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.Test;
 
 public class AzureServiceUnitTest extends BaseUnitTest {
@@ -41,7 +40,8 @@ public class AzureServiceUnitTest extends BaseUnitTest {
   @Test
   public void getManagedApps() {
     var authedTerraApp = mock(Application.class);
-    mockApplicationCalls(authedTerraApp,
+    mockApplicationCalls(
+        authedTerraApp,
         offerName,
         offerPublisher,
         Optional.of(authedUserEmail),
@@ -49,15 +49,12 @@ public class AzureServiceUnitTest extends BaseUnitTest {
         "fake_app_1");
 
     var unauthedTerraApp = mock(Application.class);
-    mockApplicationCalls(unauthedTerraApp,
-        offerName,
-        offerPublisher,
-        Optional.empty(),
-        "mrg_fake2",
-        "fake_app_2");
+    mockApplicationCalls(
+        unauthedTerraApp, offerName, offerPublisher, Optional.empty(), "mrg_fake2", "fake_app_2");
 
     var otherNonTerraApp = mock(Application.class);
-    mockApplicationCalls(otherNonTerraApp,
+    mockApplicationCalls(
+        otherNonTerraApp,
         "other_offer",
         offerPublisher,
         Optional.empty(),
@@ -65,7 +62,8 @@ public class AzureServiceUnitTest extends BaseUnitTest {
         "fake_app3");
 
     var differentPublisherApp = mock(Application.class);
-    mockApplicationCalls(differentPublisherApp,
+    mockApplicationCalls(
+        differentPublisherApp,
         offerName,
         "other_publisher",
         Optional.of(authedUserEmail),
@@ -111,7 +109,8 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     var profileDao = mock(ProfileDao.class);
 
     var authedTerraApp = mock(Application.class);
-    mockApplicationCalls(authedTerraApp,
+    mockApplicationCalls(
+        authedTerraApp,
         offerName,
         offerPublisher,
         Optional.of(authedUserEmail),
@@ -152,7 +151,8 @@ public class AzureServiceUnitTest extends BaseUnitTest {
         .thenReturn(List.of(assignedTerraAppManagedResourceGroupId));
 
     var assignedTerraApp = mock(Application.class);
-    mockApplicationCalls(assignedTerraApp,
+    mockApplicationCalls(
+        assignedTerraApp,
         offerName,
         offerPublisher,
         Optional.of(authedUserEmail),
@@ -160,15 +160,15 @@ public class AzureServiceUnitTest extends BaseUnitTest {
         applicationName);
 
     var unassignedTerraApp = mock(Application.class);
-    mockApplicationCalls(unassignedTerraApp,
+    mockApplicationCalls(
+        unassignedTerraApp,
         offerName,
         offerPublisher,
         Optional.of(authedUserEmail),
         unassignedTerraAppManagedResourceGroupId,
         applicationName);
 
-    var appsList =
-        Stream.of(assignedTerraApp, unassignedTerraApp);
+    var appsList = Stream.of(assignedTerraApp, unassignedTerraApp);
     var appService = mock(ApplicationService.class);
     when(appService.getApplicationsForSubscription(eq(subId))).thenReturn(appsList);
     when(appService.getTenantForSubscription(subId)).thenReturn(tenantId);
@@ -185,20 +185,23 @@ public class AzureServiceUnitTest extends BaseUnitTest {
             new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()),
             profileDao);
 
-    AzureManagedAppModel assignedAzureManagedAppModel = new AzureManagedAppModel()
-        .tenantId(tenantId)
-        .subscriptionId(subId)
-        .managedResourceGroupId(assignedTerraAppManagedResourceGroupId)
-        .applicationDeploymentName(applicationName);
+    AzureManagedAppModel assignedAzureManagedAppModel =
+        new AzureManagedAppModel()
+            .tenantId(tenantId)
+            .subscriptionId(subId)
+            .managedResourceGroupId(assignedTerraAppManagedResourceGroupId)
+            .applicationDeploymentName(applicationName);
 
-    AzureManagedAppModel unassignedAzureManagedAppModel = new AzureManagedAppModel()
-        .tenantId(tenantId)
-        .subscriptionId(subId)
-        .managedResourceGroupId(unassignedTerraAppManagedResourceGroupId)
-        .applicationDeploymentName(applicationName);
+    AzureManagedAppModel unassignedAzureManagedAppModel =
+        new AzureManagedAppModel()
+            .tenantId(tenantId)
+            .subscriptionId(subId)
+            .managedResourceGroupId(unassignedTerraAppManagedResourceGroupId)
+            .applicationDeploymentName(applicationName);
 
     var includeAssignedResult = azureService.getAuthorizedManagedAppDeployments(subId, true, user);
-    assertEquals(List.of(assignedAzureManagedAppModel, unassignedAzureManagedAppModel),
+    assertEquals(
+        List.of(assignedAzureManagedAppModel, unassignedAzureManagedAppModel),
         includeAssignedResult);
 
     appsList = Stream.of(assignedTerraApp, unassignedTerraApp);
@@ -225,12 +228,8 @@ public class AzureServiceUnitTest extends BaseUnitTest {
       authorizedUsers = "other@example.com";
     }
     when(application.parameters())
-        .thenReturn(
-            Map.of(
-                authorizedUserKey,
-                Map.of("value", authorizedUsers)));
-    when(application.managedResourceGroupId()).thenReturn(
-        managedResourceGroupId);
+        .thenReturn(Map.of(authorizedUserKey, Map.of("value", authorizedUsers)));
+    when(application.managedResourceGroupId()).thenReturn(managedResourceGroupId);
     when(application.name()).thenReturn(applicationName);
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
 import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.service.crl.CrlService;
 import com.azure.resourcemanager.managedapplications.models.Application;
@@ -79,6 +80,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     when(appService.getTenantForSubscription(subId)).thenReturn(tenantId);
 
     var crlService = mock(CrlService.class);
+    var profileDao = mock(ProfileDao.class);
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
     offer.setName(offerName);
@@ -89,9 +91,10 @@ public class AzureServiceUnitTest extends BaseUnitTest {
         new AzureService(
             crlService,
             appService,
-            new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()));
+            new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()),
+            profileDao);
 
-    var result = azureService.getAuthorizedManagedAppDeployments(subId, user);
+    var result = azureService.getAuthorizedManagedAppDeployments(subId, true, user);
 
     var expected =
         List.of(
@@ -117,6 +120,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     var offerPublisher = "known_terra_publisher";
 
     var crlService = mock(CrlService.class);
+    var profileDao = mock(ProfileDao.class);
 
     var authedTerraApp = mock(Application.class);
     when(authedTerraApp.plan())
@@ -143,9 +147,10 @@ public class AzureServiceUnitTest extends BaseUnitTest {
         new AzureService(
             crlService,
             appService,
-            new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()));
+            new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()),
+            profileDao);
 
-    var result = azureService.getAuthorizedManagedAppDeployments(subId, user);
+    var result = azureService.getAuthorizedManagedAppDeployments(subId, true, user);
 
     assertEquals(result.size(), 1, "Duplicate app instances should be removed");
   }

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -99,7 +99,8 @@ public class AzureServiceUnitTest extends BaseUnitTest {
                 .applicationDeploymentName("fake_app_1")
                 .tenantId(tenantId)
                 .managedResourceGroupId("mrg_fake1")
-                .subscriptionId(subId));
+                .subscriptionId(subId)
+                .assigned(false));
     assertEquals(result, expected);
   }
 
@@ -190,14 +191,16 @@ public class AzureServiceUnitTest extends BaseUnitTest {
             .tenantId(tenantId)
             .subscriptionId(subId)
             .managedResourceGroupId(assignedTerraAppManagedResourceGroupId)
-            .applicationDeploymentName(applicationName);
+            .applicationDeploymentName(applicationName)
+            .assigned(true);
 
     AzureManagedAppModel unassignedAzureManagedAppModel =
         new AzureManagedAppModel()
             .tenantId(tenantId)
             .subscriptionId(subId)
             .managedResourceGroupId(unassignedTerraAppManagedResourceGroupId)
-            .applicationDeploymentName(applicationName);
+            .applicationDeploymentName(applicationName)
+            .assigned(false);
 
     var includeAssignedResult = azureService.getAuthorizedManagedAppDeployments(subId, true, user);
     assertEquals(

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -38,33 +38,6 @@ public class AzureServiceUnitTest extends BaseUnitTest {
   String offerPublisher = "known_terra_publisher";
   String authorizedUserKey = "authorizedTerraUser";
 
-
-  public void mockApplicationCalls(
-      Application application,
-      String offerName,
-      String offerPublisher,
-      Optional<String> authedUserEmail,
-      String managedResourceGroupId,
-      String applicationName) {
-    when(application.plan())
-        .thenReturn(new Plan().withProduct(offerName).withPublisher(offerPublisher));
-
-    String authorizedUsers;
-    if (authedUserEmail.isPresent()) {
-      authorizedUsers = String.format("%s,other@example.com", authedUserEmail.get());
-    } else {
-      authorizedUsers = "other@example.com";
-    }
-    when(application.parameters())
-        .thenReturn(
-            Map.of(
-                authorizedUserKey,
-                Map.of("value", authorizedUsers)));
-    when(application.managedResourceGroupId()).thenReturn(
-        managedResourceGroupId);
-    when(application.name()).thenReturn(applicationName);
-  }
-
   @Test
   public void getManagedApps() {
     var authedTerraApp = mock(Application.class);
@@ -233,5 +206,31 @@ public class AzureServiceUnitTest extends BaseUnitTest {
 
     var excludeAssignedResult = azureService.getAuthorizedManagedAppDeployments(subId, false, user);
     assertEquals(List.of(unassignedAzureManagedAppModel), excludeAssignedResult);
+  }
+
+  private void mockApplicationCalls(
+      Application application,
+      String offerName,
+      String offerPublisher,
+      Optional<String> authedUserEmail,
+      String managedResourceGroupId,
+      String applicationName) {
+    when(application.plan())
+        .thenReturn(new Plan().withProduct(offerName).withPublisher(offerPublisher));
+
+    String authorizedUsers;
+    if (authedUserEmail.isPresent()) {
+      authorizedUsers = String.format("%s,other@example.com", authedUserEmail.get());
+    } else {
+      authorizedUsers = "other@example.com";
+    }
+    when(application.parameters())
+        .thenReturn(
+            Map.of(
+                authorizedUserKey,
+                Map.of("value", authorizedUsers)));
+    when(application.managedResourceGroupId()).thenReturn(
+        managedResourceGroupId);
+    when(application.name()).thenReturn(applicationName);
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -147,7 +147,7 @@ public class AzureServiceUnitTest extends BaseUnitTest {
 
     var crlService = mock(CrlService.class);
     var profileDao = mock(ProfileDao.class);
-    when(profileDao.listManagedResourceGroupsInSubscription(tenantId, subId))
+    when(profileDao.listManagedResourceGroupsInSubscription(subId))
         .thenReturn(List.of(assignedTerraAppManagedResourceGroupId));
 
     var assignedTerraApp = mock(Application.class);

--- a/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
@@ -108,10 +108,6 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
     var differentSubscriptionProfile =
         makeAzureProfile(tenantId, UUID.randomUUID(), managedResourceGroupId);
     assertDoesNotThrow(() -> profileDao.createBillingProfile(differentSubscriptionProfile, user));
-
-    var differentTenantProfile =
-        makeAzureProfile(UUID.randomUUID(), subscriptionId, managedResourceGroupId);
-    assertDoesNotThrow(() -> profileDao.createBillingProfile(differentTenantProfile, user));
   }
 
   @Test
@@ -175,7 +171,6 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
     UUID subscriptionId = UUID.randomUUID();
     String managedResourceGroupId = "managedResourceGroupId";
     String differentSubscriptionMRGId = "differentSubscriptionMRGId";
-    String differentTenantMRGId = "differentTenantMRGId";
 
     var profile = makeAzureProfile(tenantId, subscriptionId, managedResourceGroupId);
     profileDao.createBillingProfile(profile, user);
@@ -184,11 +179,7 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
         makeAzureProfile(tenantId, UUID.randomUUID(), differentSubscriptionMRGId);
     profileDao.createBillingProfile(differentSubscriptionProfile, user);
 
-    var differentTenantProfile =
-        makeAzureProfile(UUID.randomUUID(), subscriptionId, differentTenantMRGId);
-    profileDao.createBillingProfile(differentTenantProfile, user);
-
-    var result = profileDao.listManagedResourceGroupsInSubscription(tenantId, subscriptionId);
+    var result = profileDao.listManagedResourceGroupsInSubscription(subscriptionId);
     assertEquals(List.of(managedResourceGroupId), result);
   }
 

--- a/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
@@ -26,7 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 
 public class ProfileDaoTest extends BaseSpringUnitTest {
-  @Autowired private ProfileDao profileDao;
+
+  @Autowired
+  private ProfileDao profileDao;
   private AuthenticatedUserRequest user;
   private List<UUID> profileIds;
 
@@ -74,18 +76,18 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
     UUID profileId = UUID.randomUUID();
     profileIds.add(profileId);
     var profile = new BillingProfile(
-            profileId,
-            "test profile",
-            "",
-            "direct",
-            CloudPlatform.AZURE,
-            Optional.empty(),
-            Optional.of(tenantId),
-            Optional.of(subscriptionId),
-            Optional.of(managedResourceGroupId),
-            null,
-            null,
-            null
+        profileId,
+        "test profile",
+        "",
+        "direct",
+        CloudPlatform.AZURE,
+        Optional.empty(),
+        Optional.of(tenantId),
+        Optional.of(subscriptionId),
+        Optional.of(managedResourceGroupId),
+        null,
+        null,
+        null
     );
 
     var createResult = profileDao.createBillingProfile(profile, user);
@@ -94,23 +96,43 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
     UUID duplicatedProfileId = UUID.randomUUID();
     profileIds.add(duplicatedProfileId);
     var duplicatedManagedAppCoordsProfile = new BillingProfile(
-            duplicatedProfileId,
-            "get your own managed app",
-            "",
-            "direct",
-            CloudPlatform.AZURE,
-            Optional.empty(),
-            Optional.of(tenantId),
-            Optional.of(subscriptionId),
-            Optional.of(managedResourceGroupId),
-            null,
-            null,
-            null
+        duplicatedProfileId,
+        "get your own managed app",
+        "",
+        "direct",
+        CloudPlatform.AZURE,
+        Optional.empty(),
+        Optional.of(tenantId),
+        Optional.of(subscriptionId),
+        Optional.of(managedResourceGroupId),
+        null,
+        null,
+        null
     );
 
     assertThrows(
-            DuplicateManagedApplicationException.class,
-            () -> profileDao.createBillingProfile(duplicatedManagedAppCoordsProfile, user));
+        DuplicateManagedApplicationException.class,
+        () -> profileDao.createBillingProfile(duplicatedManagedAppCoordsProfile, user));
+
+    UUID differentMRGIdProfileId = UUID.randomUUID();
+    profileIds.add(differentMRGIdProfileId);
+    var differentMRGProfile = new BillingProfile(
+        differentMRGIdProfileId,
+        "get your own managed app",
+        "",
+        "direct",
+        CloudPlatform.AZURE,
+        Optional.empty(),
+        Optional.of(tenantId),
+        Optional.of(subscriptionId),
+        Optional.of("new_managed_resource_group"),
+        null,
+        null,
+        null
+    );
+
+    createResult = profileDao.createBillingProfile(differentMRGProfile, user);
+    assertProfileEquals(differentMRGProfile, createResult);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/profile/service/db/ProfileDaoTest.java
@@ -28,8 +28,7 @@ import org.springframework.dao.DuplicateKeyException;
 
 public class ProfileDaoTest extends BaseSpringUnitTest {
 
-  @Autowired
-  private ProfileDao profileDao;
+  @Autowired private ProfileDao profileDao;
   private AuthenticatedUserRequest user;
   private List<UUID> profileIds;
 
@@ -83,41 +82,35 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
 
     UUID duplicatedProfileId = UUID.randomUUID();
     profileIds.add(duplicatedProfileId);
-    var duplicatedManagedAppCoordsProfile = new BillingProfile(
-        duplicatedProfileId,
-        "get your own managed app",
-        "",
-        "direct",
-        CloudPlatform.AZURE,
-        Optional.empty(),
-        Optional.of(tenantId),
-        Optional.of(subscriptionId),
-        Optional.of(managedResourceGroupId),
-        null,
-        null,
-        null
-    );
+    var duplicatedManagedAppCoordsProfile =
+        new BillingProfile(
+            duplicatedProfileId,
+            "get your own managed app",
+            "",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.empty(),
+            Optional.of(tenantId),
+            Optional.of(subscriptionId),
+            Optional.of(managedResourceGroupId),
+            null,
+            null,
+            null);
 
     assertThrows(
         DuplicateManagedApplicationException.class,
         () -> profileDao.createBillingProfile(duplicatedManagedAppCoordsProfile, user));
 
     var differentMRGProfile =
-        makeAzureProfile(tenantId,
-            subscriptionId,
-            "new_managed_resource_group");
+        makeAzureProfile(tenantId, subscriptionId, "new_managed_resource_group");
     assertDoesNotThrow(() -> profileDao.createBillingProfile(differentMRGProfile, user));
 
     var differentSubscriptionProfile =
-        makeAzureProfile(tenantId,
-            UUID.randomUUID(),
-            managedResourceGroupId);
+        makeAzureProfile(tenantId, UUID.randomUUID(), managedResourceGroupId);
     assertDoesNotThrow(() -> profileDao.createBillingProfile(differentSubscriptionProfile, user));
 
     var differentTenantProfile =
-        makeAzureProfile(UUID.randomUUID(),
-            subscriptionId,
-            managedResourceGroupId);
+        makeAzureProfile(UUID.randomUUID(), subscriptionId, managedResourceGroupId);
     assertDoesNotThrow(() -> profileDao.createBillingProfile(differentTenantProfile, user));
   }
 
@@ -188,15 +181,11 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
     profileDao.createBillingProfile(profile, user);
 
     var differentSubscriptionProfile =
-        makeAzureProfile(tenantId,
-            UUID.randomUUID(),
-            differentSubscriptionMRGId);
+        makeAzureProfile(tenantId, UUID.randomUUID(), differentSubscriptionMRGId);
     profileDao.createBillingProfile(differentSubscriptionProfile, user);
 
     var differentTenantProfile =
-        makeAzureProfile(UUID.randomUUID(),
-            subscriptionId,
-            differentTenantMRGId);
+        makeAzureProfile(UUID.randomUUID(), subscriptionId, differentTenantMRGId);
     profileDao.createBillingProfile(differentTenantProfile, user);
 
     var result = profileDao.listManagedResourceGroupsInSubscription(tenantId, subscriptionId);
@@ -222,8 +211,8 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
         null);
   }
 
-  private BillingProfile makeAzureProfile(UUID tenantId, UUID subscriptionId,
-      String managedResourceGroupId) {
+  private BillingProfile makeAzureProfile(
+      UUID tenantId, UUID subscriptionId, String managedResourceGroupId) {
     UUID profileId = UUID.randomUUID();
     profileIds.add(profileId);
     return new BillingProfile(
@@ -238,8 +227,7 @@ public class ProfileDaoTest extends BaseSpringUnitTest {
         Optional.of(managedResourceGroupId),
         null,
         null,
-        null
-    );
+        null);
   }
 
   // Tests profile equality, ignoring createdTime and createdBy

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -141,7 +141,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
 
   @Test
   void createAzureProfileInaccessibleAppDeployment() {
-    when(azureService.getAuthorizedManagedAppDeployments(any(), any()))
+    when(azureService.getAuthorizedManagedAppDeployments(any(), any(), any()))
         .thenReturn(Collections.emptyList());
 
     var profile =
@@ -170,7 +170,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
     var tenantId = UUID.randomUUID();
     var mrgId = "fake-mrg";
 
-    when(azureService.getAuthorizedManagedAppDeployments(any(), any()))
+    when(azureService.getAuthorizedManagedAppDeployments(any(), any(), any()))
         .thenReturn(
             Collections.singletonList(
                 new AzureManagedAppModel()

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
@@ -71,7 +71,7 @@ class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUnitTest 
 
   @Test
   void verifyManagedApp() {
-    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user))
+    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), true, user))
         .thenReturn(
             List.of(
                 new AzureManagedAppModel()
@@ -92,7 +92,7 @@ class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUnitTest 
 
   @Test
   void missingProviders() {
-    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), user))
+    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), true, user))
         .thenReturn(
             List.of(
                 new AzureManagedAppModel()

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
@@ -71,7 +71,8 @@ class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUnitTest 
 
   @Test
   void verifyManagedApp() {
-    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), true, user))
+    when(azureService.getAuthorizedManagedAppDeployments(
+            profile.subscriptionId().get(), true, user))
         .thenReturn(
             List.of(
                 new AzureManagedAppModel()
@@ -92,7 +93,8 @@ class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUnitTest 
 
   @Test
   void missingProviders() {
-    when(azureService.getAuthorizedManagedAppDeployments(profile.subscriptionId().get(), true, user))
+    when(azureService.getAuthorizedManagedAppDeployments(
+            profile.subscriptionId().get(), true, user))
         .thenReturn(
             List.of(
                 new AzureManagedAppModel()


### PR DESCRIPTION
Ticket: [WOR-156](https://broadworkbench.atlassian.net/browse/WOR-156)
* add uniqueness constraint to prevent multiple billing profiles with the same managed app coordinates
* add optional query parameter to `listManagedApps` endpoint to specify whether to include managed apps that are already assigned to a billing profile