### PR TITLE
[WOR-515] Return 403 instead of 401 when user lacks access to a profile

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -1,6 +1,6 @@
 package bio.terra.profile.service.profile;
 
-import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.SamPolicyModel;
@@ -102,7 +102,7 @@ public class ProfileService {
         SamRethrow.onInterrupted(
             () -> samService.hasActions(user, SamResourceType.PROFILE, id), "hasActions");
     if (!hasActions) {
-      throw new UnauthorizedException("unauthorized");
+      throw new ForbiddenException("forbidden");
     }
     return profile;
   }

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -2,18 +2,11 @@ package bio.terra.profile.service.profile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.NotFoundException;
-import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.db.ProfileDao;
@@ -143,7 +136,7 @@ public class ProfileServiceUnitTest extends BaseSpringUnitTest {
   public void getProfileNoAccess() throws InterruptedException {
     when(samService.hasActions(eq(user), eq(SamResourceType.PROFILE), eq(profile.id())))
         .thenReturn(false);
-    assertThrows(UnauthorizedException.class, () -> profileService.getProfile(profile.id(), user));
+    assertThrows(ForbiddenException.class, () -> profileService.getProfile(profile.id(), user));
   }
 
   @Test


### PR DESCRIPTION
We are returning 401 UNAUTHORIZED when a user does not have access to a profile. We should return 403 FORBIDDEN as that is a more accurate status code -- 401 generally indicates a bad authentication credential, which is not the case here. 403 should be used to indicate the credential is good but the server is not allowing access to the desired resource. 