### PR TITLE
Pull in this fix from rawls

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Secrets check
         run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
           ./minnie-kenny.sh --force
           git secrets --scan-history
 


### PR DESCRIPTION
We are encountering an issue with the lack of a `git say`, which causes `git secrets` to fail to install. This pulls in a workaround that I believe is working for Rawls. 