### PR TITLE
[WOR-556] Upgrade Spring to 5.3.23

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -48,9 +48,6 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
-// https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement
-ext['spring-framework.version'] = '5.3.18'
-
 // Modify the standard :test task to only include unit-tagged tests.
 tasks.named('test') {
     useJUnitPlatform() {


### PR DESCRIPTION
Ticket: [WOR-556](https://broadworkbench.atlassian.net/browse/WOR-556)
* Turns out we were explicitly setting the spring-framework version to avoid a different vulnerability. I removed this and confirmed that it now pulls in 5.3.23 instead of 5.3.18.