### PR TITLE
WOR-634

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -78,12 +78,14 @@ public class ApplicationService {
    * @param tag Tag name
    * @throws MissingRequiredFieldsException if the tag is not present.
    */
-  public void removeTagFromMrg(UUID tenantId, UUID subscriptionId, String managedResourceGroupId, String tag) {
+  public void removeTagFromMrg(
+      UUID tenantId, UUID subscriptionId, String managedResourceGroupId, String tag) {
     var mrgResource = crlService.getResourceGroup(tenantId, subscriptionId, managedResourceGroupId);
     if (!mrgResource.tags().containsKey(tag)) {
       throw new MissingRequiredFieldsException(
-          String.format("Cannot delete missing tag from MRG [mrg_id = %s, tag = %s]", managedResourceGroupId, tag)
-      );
+          String.format(
+              "Cannot delete missing tag from MRG [mrg_id = %s, tag = %s]",
+              managedResourceGroupId, tag));
     }
 
     // dupe existing tags to a mutable hashmap
@@ -91,6 +93,4 @@ public class ApplicationService {
     tags.remove(tag);
     crlService.updateTagsForResource(tenantId, subscriptionId, mrgResource.id(), tags);
   }
-
-
 }

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -2,7 +2,6 @@ package bio.terra.profile.service.azure;
 
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.DuplicateTagException;
-import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import com.azure.resourcemanager.managedapplications.models.Application;
 import java.util.HashMap;
 import java.util.UUID;
@@ -76,7 +75,6 @@ public class ApplicationService {
    * @param subscriptionId Subscription ID associated with the MRG
    * @param managedResourceGroupId ID for the MRG
    * @param tag Tag name
-   * @throws MissingRequiredFieldsException if the tag is not present.
    */
   public void removeTagFromMrg(
       UUID tenantId, UUID subscriptionId, String managedResourceGroupId, String tag) {

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -81,16 +81,13 @@ public class ApplicationService {
   public void removeTagFromMrg(
       UUID tenantId, UUID subscriptionId, String managedResourceGroupId, String tag) {
     var mrgResource = crlService.getResourceGroup(tenantId, subscriptionId, managedResourceGroupId);
-    if (!mrgResource.tags().containsKey(tag)) {
-      throw new MissingRequiredFieldsException(
-          String.format(
-              "Cannot delete missing tag from MRG [mrg_id = %s, tag = %s]",
-              managedResourceGroupId, tag));
+    if (mrgResource.tags().containsKey(tag)) {
+      // dupe existing tags to a mutable hashmap
+      HashMap<String, String> tags = new HashMap<>(mrgResource.tags());
+      tags.remove(tag);
+      crlService.updateTagsForResource(tenantId, subscriptionId, mrgResource.id(), tags);
     }
 
-    // dupe existing tags to a mutable hashmap
-    HashMap<String, String> tags = new HashMap<>(mrgResource.tags());
-    tags.remove(tag);
-    crlService.updateTagsForResource(tenantId, subscriptionId, mrgResource.id(), tags);
+
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -87,7 +87,5 @@ public class ApplicationService {
       tags.remove(tag);
       crlService.updateTagsForResource(tenantId, subscriptionId, mrgResource.id(), tags);
     }
-
-
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -3,7 +3,6 @@ package bio.terra.profile.service.profile;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
-import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.model.SamPolicyModel;
 import bio.terra.profile.service.iam.SamRethrow;
 import bio.terra.profile.service.iam.SamService;

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -3,6 +3,7 @@ package bio.terra.profile.service.profile;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
+import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.model.SamPolicyModel;
 import bio.terra.profile.service.iam.SamRethrow;
 import bio.terra.profile.service.iam.SamService;
@@ -83,6 +84,10 @@ public class ProfileService {
             .userRequest(user)
             .addParameter(ProfileMapKeys.PROFILE_ID, id)
             .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name());
+    if (CloudPlatform.AZURE.equals(billingProfile.cloudPlatform())) {
+      deleteJob.addParameter(ProfileMapKeys.PROFILE, billingProfile);
+    }
+
     deleteJob.submitAndWait(null);
   }
 

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -82,12 +82,8 @@ public class ProfileService {
             .description(description)
             .flightClass(DeleteProfileFlight.class)
             .userRequest(user)
-            .addParameter(ProfileMapKeys.PROFILE_ID, id)
+            .addParameter(ProfileMapKeys.PROFILE, billingProfile)
             .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name());
-    if (CloudPlatform.AZURE.equals(billingProfile.cloudPlatform())) {
-      deleteJob.addParameter(ProfileMapKeys.PROFILE, billingProfile);
-    }
-
     deleteJob.submitAndWait(null);
   }
 

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/MRGTags.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/MRGTags.java
@@ -1,0 +1,7 @@
+package bio.terra.profile.service.profile.flight;
+
+public class MRGTags {
+  public static final String BILLING_PROFILE_ID = "terra.billingProfileId";
+
+  private MRGTags() {}
+}

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/ProfileMapKeys.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/ProfileMapKeys.java
@@ -1,7 +1,6 @@
 package bio.terra.profile.service.profile.flight;
 
 public final class ProfileMapKeys {
-  public static final String PROFILE_ID = "profileId";
   public static final String PROFILE = "profile";
 
   private ProfileMapKeys() {}

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/ProfileMapKeys.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/ProfileMapKeys.java
@@ -2,6 +2,7 @@ package bio.terra.profile.service.profile.flight;
 
 public final class ProfileMapKeys {
   public static final String PROFILE_ID = "profileId";
+  public static final String PROFILE = "profile";
 
   private ProfileMapKeys() {}
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -31,6 +31,14 @@ public record LinkBillingProfileIdToMrgStep(
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
-    return StepResult.getStepResultSuccess();
+    try {
+      var tenantId = profile.getRequiredTenantId();
+      var subscriptionId = profile.getRequiredSubscriptionId();
+      var mrgId = profile.getRequiredManagedResourceGroupId();
+      applicationService.removeTagFromMrg(tenantId, subscriptionId, mrgId, BILLING_PROFILE_ID_TAG);
+      return StepResult.getStepResultSuccess();
+    } catch (Exception ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+    }
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -1,6 +1,7 @@
 package bio.terra.profile.service.profile.flight.create;
 
 import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.profile.flight.MRGTags;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
@@ -11,7 +12,6 @@ import bio.terra.stairway.exception.RetryException;
 /** Add a tag that associates a billing profile ID with an azure managed resource group */
 public record LinkBillingProfileIdToMrgStep(
     ApplicationService applicationService, BillingProfile profile) implements Step {
-  private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
@@ -21,7 +21,7 @@ public record LinkBillingProfileIdToMrgStep(
       var mrgId = profile.getRequiredManagedResourceGroupId();
 
       applicationService.addTagToMrg(
-          tenantId, subscriptionId, mrgId, BILLING_PROFILE_ID_TAG, profile.id().toString());
+          tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID, profile.id().toString());
 
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
@@ -35,7 +35,8 @@ public record LinkBillingProfileIdToMrgStep(
       var tenantId = profile.getRequiredTenantId();
       var subscriptionId = profile.getRequiredSubscriptionId();
       var mrgId = profile.getRequiredManagedResourceGroupId();
-      applicationService.removeTagFromMrg(tenantId, subscriptionId, mrgId, BILLING_PROFILE_ID_TAG);
+      applicationService.removeTagFromMrg(
+          tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStep.java
@@ -31,15 +31,11 @@ public record LinkBillingProfileIdToMrgStep(
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
-    try {
-      var tenantId = profile.getRequiredTenantId();
-      var subscriptionId = profile.getRequiredSubscriptionId();
-      var mrgId = profile.getRequiredManagedResourceGroupId();
-      applicationService.removeTagFromMrg(
-          tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
-      return StepResult.getStepResultSuccess();
-    } catch (Exception ex) {
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
-    }
+    var tenantId = profile.getRequiredTenantId();
+    var subscriptionId = profile.getRequiredSubscriptionId();
+    var mrgId = profile.getRequiredManagedResourceGroupId();
+    applicationService.removeTagFromMrg(
+        tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
+    return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
@@ -23,7 +23,8 @@ public class DeleteProfileFlight extends Flight {
     SamService samService = appContext.getBean(SamService.class);
     ApplicationService appService = appContext.getBean(ApplicationService.class);
 
-    var profileId = inputParameters.get(ProfileMapKeys.PROFILE_ID, UUID.class);
+    var profile = inputParameters.get(ProfileMapKeys.PROFILE, BillingProfile.class);
+    var profileId = profile.id();
     var platform = inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), CloudPlatform.class);
     var user =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
@@ -32,7 +33,6 @@ public class DeleteProfileFlight extends Flight {
     // workspaces/datasets?
 
     if (CloudPlatform.AZURE.equals(platform)) {
-      var profile = inputParameters.get(ProfileMapKeys.PROFILE, BillingProfile.class);
       addStep(new UnlinkBillingProfileIdFromMrgStep(appService, profile));
     }
     addStep(new DeleteProfileStep(profileDao, profileId));

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
@@ -4,7 +4,6 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.azure.ApplicationService;
-import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.job.JobMapKeys;
 import bio.terra.profile.service.profile.flight.ProfileMapKeys;
@@ -24,7 +23,6 @@ public class DeleteProfileFlight extends Flight {
     SamService samService = appContext.getBean(SamService.class);
     ApplicationService appService = appContext.getBean(ApplicationService.class);
 
-
     var profileId = inputParameters.get(ProfileMapKeys.PROFILE_ID, UUID.class);
     var platform = inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), CloudPlatform.class);
     var user =
@@ -33,7 +31,7 @@ public class DeleteProfileFlight extends Flight {
     // TODO what is the correct logic when a profile is deleted if it is being used by
     // workspaces/datasets?
 
-    if(CloudPlatform.AZURE.equals(platform)) {
+    if (CloudPlatform.AZURE.equals(platform)) {
       var profile = inputParameters.get(ProfileMapKeys.PROFILE, BillingProfile.class);
       addStep(new UnlinkBillingProfileIdFromMrgStep(appService, profile));
     }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
@@ -10,7 +10,6 @@ import bio.terra.profile.service.profile.flight.ProfileMapKeys;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import java.util.UUID;
 import org.springframework.context.ApplicationContext;
 
 public class DeleteProfileFlight extends Flight {

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlight.java
@@ -3,10 +3,12 @@ package bio.terra.profile.service.profile.flight.delete;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.service.azure.ApplicationService;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.job.JobMapKeys;
 import bio.terra.profile.service.profile.flight.ProfileMapKeys;
+import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import java.util.UUID;
@@ -19,8 +21,9 @@ public class DeleteProfileFlight extends Flight {
 
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     ProfileDao profileDao = appContext.getBean(ProfileDao.class);
-    CrlService crlService = appContext.getBean(CrlService.class);
     SamService samService = appContext.getBean(SamService.class);
+    ApplicationService appService = appContext.getBean(ApplicationService.class);
+
 
     var profileId = inputParameters.get(ProfileMapKeys.PROFILE_ID, UUID.class);
     var platform = inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), CloudPlatform.class);
@@ -30,6 +33,10 @@ public class DeleteProfileFlight extends Flight {
     // TODO what is the correct logic when a profile is deleted if it is being used by
     // workspaces/datasets?
 
+    if(CloudPlatform.AZURE.equals(platform)) {
+      var profile = inputParameters.get(ProfileMapKeys.PROFILE, BillingProfile.class);
+      addStep(new UnlinkBillingProfileIdFromMrgStep(appService, profile));
+    }
     addStep(new DeleteProfileStep(profileDao, profileId));
     addStep(new DeleteProfileAuthzIamStep(samService, profileId, user));
   }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
@@ -15,22 +15,29 @@ public record UnlinkBillingProfileIdFromMrgStep(
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    var tenantId = profile.getRequiredTenantId();
+    var subscriptionId = profile.getRequiredSubscriptionId();
+    var mrgId = profile.getRequiredManagedResourceGroupId();
+
+    applicationService.removeTagFromMrg(
+        tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
     try {
       var tenantId = profile.getRequiredTenantId();
       var subscriptionId = profile.getRequiredSubscriptionId();
       var mrgId = profile.getRequiredManagedResourceGroupId();
 
-      applicationService.removeTagFromMrg(
-          tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
+      applicationService.addTagToMrg(
+          tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID, profile.id().toString());
 
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
-    return StepResult.getStepResultSuccess();
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
@@ -8,13 +8,9 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 
-/**
- * Removes the tag that associates a billing profile ID with an azure managed resource group
- **/
+/** Removes the tag that associates a billing profile ID with an azure managed resource group */
 public record UnlinkBillingProfileIdFromMrgStep(
-    ApplicationService applicationService,
-    BillingProfile profile
-) implements Step {
+    ApplicationService applicationService, BillingProfile profile) implements Step {
   private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
 
   @Override
@@ -36,6 +32,4 @@ public record UnlinkBillingProfileIdFromMrgStep(
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
-
 }
-

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
@@ -1,6 +1,7 @@
 package bio.terra.profile.service.profile.flight.delete;
 
 import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.profile.flight.MRGTags;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
@@ -11,7 +12,6 @@ import bio.terra.stairway.exception.RetryException;
 /** Removes the tag that associates a billing profile ID with an azure managed resource group */
 public record UnlinkBillingProfileIdFromMrgStep(
     ApplicationService applicationService, BillingProfile profile) implements Step {
-  private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
@@ -20,7 +20,8 @@ public record UnlinkBillingProfileIdFromMrgStep(
       var subscriptionId = profile.getRequiredSubscriptionId();
       var mrgId = profile.getRequiredManagedResourceGroupId();
 
-      applicationService.removeTagFromMrg(tenantId, subscriptionId, mrgId, BILLING_PROFILE_ID_TAG);
+      applicationService.removeTagFromMrg(
+          tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
 
       return StepResult.getStepResultSuccess();
     } catch (Exception ex) {

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStep.java
@@ -1,0 +1,41 @@
+package bio.terra.profile.service.profile.flight.delete;
+
+import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.profile.model.BillingProfile;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+
+/**
+ * Removes the tag that associates a billing profile ID with an azure managed resource group
+ **/
+public record UnlinkBillingProfileIdFromMrgStep(
+    ApplicationService applicationService,
+    BillingProfile profile
+) implements Step {
+  private static final String BILLING_PROFILE_ID_TAG = "terra.billingProfileId";
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    try {
+      var tenantId = profile.getRequiredTenantId();
+      var subscriptionId = profile.getRequiredSubscriptionId();
+      var mrgId = profile.getRequiredManagedResourceGroupId();
+
+      applicationService.removeTagFromMrg(tenantId, subscriptionId, mrgId, BILLING_PROFILE_ID_TAG);
+
+      return StepResult.getStepResultSuccess();
+    } catch (Exception ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+    }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+
+}
+

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -70,7 +70,7 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
   }
 
   @Test
-  void removeTagFromMrg_failsWhenTagIsMissing() {
+  void removeTagFromMrg_doesNothingWhenTagIsMissing() {
     var tenantId = UUID.randomUUID();
     var subId = UUID.randomUUID();
     var mrgId = "fake_mrg_id";
@@ -82,9 +82,7 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
     when(crlService.getResourceGroup(tenantId, subId, mrgId)).thenReturn(resourceGroup);
     var applicationService = new ApplicationService(crlService);
 
-    assertThrows(
-        MissingRequiredFieldsException.class,
-        () -> applicationService.removeTagFromMrg(tenantId, subId, mrgId, "fake_tag"));
+    applicationService.removeTagFromMrg(tenantId, subId, mrgId, "fake_tag");
 
     verify(crlService, never().description("Should not attempt to add a tag if there is a dupe"))
         .updateTagsForResource(any(), any(), any(), any());

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.DuplicateTagException;
+import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
 import java.util.Map;
 import java.util.UUID;
@@ -47,6 +48,45 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
         () -> applicationService.addTagToMrg(tenantId, subId, mrgId, "fake_tag", "fake_value"));
 
     verify(crlService, times(0).description("Should not attempt to add a tag if there is a dupe"))
+        .updateTagsForResource(any(), any(), any(), any());
+  }
+
+  @Test
+  void removeTagFromMrg() {
+    var tenantId = UUID.randomUUID();
+    var subId = UUID.randomUUID();
+    var mrgId = "fake_mrg_id";
+    var crlService = mock(CrlService.class);
+    var resourceGroup = mock(ResourceGroup.class);
+    var resourceGroupId = UUID.randomUUID().toString();
+    when(resourceGroup.id()).thenReturn(resourceGroupId);
+    when(resourceGroup.tags()).thenReturn(Map.of("fake_tag", "fake_value"));
+    when(crlService.getResourceGroup(tenantId, subId, mrgId)).thenReturn(resourceGroup);
+    var applicationService = new ApplicationService(crlService);
+
+    applicationService.removeTagFromMrg(tenantId, subId, mrgId, "fake_tag");
+
+    verify(crlService).updateTagsForResource(tenantId, subId, resourceGroupId, Map.of());
+  }
+
+  @Test
+  void removeTagFromMrg_failsWhenTagIsMissing() {
+    var tenantId = UUID.randomUUID();
+    var subId = UUID.randomUUID();
+    var mrgId = "fake_mrg_id";
+    var crlService = mock(CrlService.class);
+    var resourceGroup = mock(ResourceGroup.class);
+    var resourceGroupId = UUID.randomUUID().toString();
+    when(resourceGroup.id()).thenReturn(resourceGroupId);
+    when(resourceGroup.tags()).thenReturn(Map.of());
+    when(crlService.getResourceGroup(tenantId, subId, mrgId)).thenReturn(resourceGroup);
+    var applicationService = new ApplicationService(crlService);
+
+    assertThrows(
+        MissingRequiredFieldsException.class,
+        () -> applicationService.removeTagFromMrg(tenantId, subId, mrgId, "fake_tag"));
+
+    verify(crlService, never().description("Should not attempt to add a tag if there is a dupe"))
         .updateTagsForResource(any(), any(), any(), any());
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.DuplicateTagException;
-import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
 import java.util.Map;
 import java.util.UUID;

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -99,8 +99,7 @@ public class ProfileServiceUnitTest extends BaseSpringUnitTest {
     when(jobBuilder.description(anyString())).thenReturn(jobBuilder);
     when(jobBuilder.flightClass(eq(DeleteProfileFlight.class))).thenReturn(jobBuilder);
     when(jobBuilder.userRequest(eq(user))).thenReturn(jobBuilder);
-    when(jobBuilder.addParameter(eq(ProfileMapKeys.PROFILE), eq(profile)))
-        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(eq(ProfileMapKeys.PROFILE), eq(profile))).thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
             eq(JobMapKeys.CLOUD_PLATFORM.getKeyName()), eq(CloudPlatform.GCP.name())))
         .thenReturn(jobBuilder);

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -99,7 +99,7 @@ public class ProfileServiceUnitTest extends BaseSpringUnitTest {
     when(jobBuilder.description(anyString())).thenReturn(jobBuilder);
     when(jobBuilder.flightClass(eq(DeleteProfileFlight.class))).thenReturn(jobBuilder);
     when(jobBuilder.userRequest(eq(user))).thenReturn(jobBuilder);
-    when(jobBuilder.addParameter(eq(ProfileMapKeys.PROFILE_ID), eq(profile.id())))
+    when(jobBuilder.addParameter(eq(ProfileMapKeys.PROFILE), eq(profile)))
         .thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
             eq(JobMapKeys.CLOUD_PLATFORM.getKeyName()), eq(CloudPlatform.GCP.name())))

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -218,7 +218,6 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
                     .managedResourceGroupId(mrgId)));
     when(azureService.getRegisteredProviderNamespacesForSubscription(any(), any()))
         .thenReturn(azureConfiguration.getRequiredProviders());
-
     doThrow(SamExceptionFactory.create("foo", new InterruptedException()))
         .when(samService).createProfileResource(any(), eq(billingProfileId));
 
@@ -240,7 +239,6 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
 
     verify(applicationService)
         .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
-
     verify(applicationService).removeTagFromMrg(tenantId, subId, mrgId, "terra.billingProfileId");
   }
 

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -20,6 +20,7 @@ import bio.terra.profile.service.profile.ProfileService;
 import bio.terra.profile.service.profile.exception.InaccessibleApplicationDeploymentException;
 import bio.terra.profile.service.profile.exception.InaccessibleBillingAccountException;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
+import bio.terra.profile.service.profile.flight.MRGTags;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import java.util.Collections;
@@ -200,7 +201,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
     profileService.createProfile(profile, userRequest);
 
     verify(applicationService)
-        .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
+        .addTagToMrg(tenantId, subId, mrgId, MRGTags.BILLING_PROFILE_ID, profile.id().toString());
   }
 
   @Test
@@ -240,7 +241,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
         SamInterruptedException.class, () -> profileService.createProfile(profile, userRequest));
 
     verify(applicationService)
-        .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
-    verify(applicationService).removeTagFromMrg(tenantId, subId, mrgId, "terra.billingProfileId");
+        .addTagToMrg(tenantId, subId, mrgId, MRGTags.BILLING_PROFILE_ID, profile.id().toString());
+    verify(applicationService).removeTagFromMrg(tenantId, subId, mrgId, MRGTags.BILLING_PROFILE_ID);
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -219,7 +219,8 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
     when(azureService.getRegisteredProviderNamespacesForSubscription(any(), any()))
         .thenReturn(azureConfiguration.getRequiredProviders());
     doThrow(SamExceptionFactory.create("foo", new InterruptedException()))
-        .when(samService).createProfileResource(any(), eq(billingProfileId));
+        .when(samService)
+        .createProfileResource(any(), eq(billingProfileId));
 
     var profile =
         new BillingProfile(
@@ -235,11 +236,11 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
             null,
             null,
             null);
-    assertThrows(SamInterruptedException.class, () -> profileService.createProfile(profile, userRequest));
+    assertThrows(
+        SamInterruptedException.class, () -> profileService.createProfile(profile, userRequest));
 
     verify(applicationService)
         .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
     verify(applicationService).removeTagFromMrg(tenantId, subId, mrgId, "terra.billingProfileId");
   }
-
 }

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.*;
 
 import bio.terra.cloudres.google.billing.CloudBillingClientCow;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.sam.exception.SamExceptionFactory;
+import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.profile.app.configuration.AzureConfiguration;
 import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.model.AzureManagedAppModel;
@@ -200,4 +202,46 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
     verify(applicationService)
         .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
   }
+
+  @Test
+  void tagIsRemovedFromMRGOnFailure() throws Exception {
+    var subId = UUID.randomUUID();
+    var tenantId = UUID.randomUUID();
+    var mrgId = "fake-mrg";
+    var billingProfileId = UUID.randomUUID();
+    when(azureService.getAuthorizedManagedAppDeployments(any(), any(), any()))
+        .thenReturn(
+            Collections.singletonList(
+                new AzureManagedAppModel()
+                    .tenantId(tenantId)
+                    .subscriptionId(subId)
+                    .managedResourceGroupId(mrgId)));
+    when(azureService.getRegisteredProviderNamespacesForSubscription(any(), any()))
+        .thenReturn(azureConfiguration.getRequiredProviders());
+
+    doThrow(SamExceptionFactory.create("foo", new InterruptedException()))
+        .when(samService).createProfileResource(any(), eq(billingProfileId));
+
+    var profile =
+        new BillingProfile(
+            billingProfileId,
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.empty(),
+            Optional.of(tenantId),
+            Optional.of(subId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+    assertThrows(SamInterruptedException.class, () -> profileService.createProfile(profile, userRequest));
+
+    verify(applicationService)
+        .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
+
+    verify(applicationService).removeTagFromMrg(tenantId, subId, mrgId, "terra.billingProfileId");
+  }
+
 }

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStepUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/LinkBillingProfileIdToMrgStepUnitTest.java
@@ -1,0 +1,80 @@
+package bio.terra.profile.service.profile.flight.create;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.profile.flight.MRGTags;
+import bio.terra.profile.service.profile.model.BillingProfile;
+import bio.terra.stairway.FlightContext;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class LinkBillingProfileIdToMrgStepUnitTest extends BaseUnitTest {
+
+  @Test
+  void linkinBillingProfileAddsTagToMRG() throws Exception {
+    var tenantId = UUID.randomUUID();
+    var subscriptionId = UUID.randomUUID();
+    var mrgId = "test-MRG-ID";
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.of("ABCDEF-1234"),
+            Optional.of(tenantId),
+            Optional.of(subscriptionId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+    ApplicationService applicationService = mock(ApplicationService.class);
+
+    var step = new LinkBillingProfileIdToMrgStep(applicationService, profile);
+
+    var flightContext = mock(FlightContext.class);
+    step.doStep(flightContext);
+
+    verify(applicationService)
+        .addTagToMrg(
+            tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID, profile.id().toString());
+  }
+
+  @Test
+  void undoStepRemovesTagFromMRG() throws Exception {
+    var tenantId = UUID.randomUUID();
+    var subscriptionId = UUID.randomUUID();
+    var mrgId = "test-MRG-ID";
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.of("ABCDEF-1234"),
+            Optional.of(tenantId),
+            Optional.of(subscriptionId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+    ApplicationService applicationService = mock(ApplicationService.class);
+
+    var step = new LinkBillingProfileIdToMrgStep(applicationService, profile);
+
+    var flightContext = mock(FlightContext.class);
+    step.undoStep(flightContext);
+
+    verify(applicationService)
+        .removeTagFromMrg(tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
+  }
+}

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
@@ -1,0 +1,101 @@
+package bio.terra.profile.service.profile.flight.delete;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.profile.app.configuration.AzureConfiguration;
+import bio.terra.profile.common.BaseSpringUnitTest;
+import bio.terra.profile.db.ProfileDao;
+import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.azure.AzureService;
+import bio.terra.profile.service.crl.CrlService;
+import bio.terra.profile.service.iam.SamService;
+import bio.terra.profile.service.profile.ProfileService;
+import bio.terra.profile.service.profile.model.BillingProfile;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+public class DeleteProfileFlightTest extends BaseSpringUnitTest {
+
+  @Autowired
+  ProfileService profileService;
+  @Autowired
+  AzureConfiguration azureConfiguration;
+  @MockBean
+  CrlService crlService;
+
+  @MockBean
+  ProfileDao profileDao;
+  @MockBean
+  SamService samService;
+  @MockBean
+  AzureService azureService;
+  @MockBean
+  ApplicationService applicationService;
+
+  AuthenticatedUserRequest userRequest =
+      AuthenticatedUserRequest.builder()
+          .setToken("fake-token")
+          .setSubjectId("fake-sub")
+          .setEmail("example@example.com")
+          .build();
+
+
+  @Test
+  void deletingAzureProfileUnlinksMRG() {
+    var tenantId = UUID.randomUUID();
+    var subscriptionId = UUID.randomUUID();
+    var mrgId = "test-MRG-ID";
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.of("ABCDEF-1234"),
+            Optional.of(tenantId),
+            Optional.of(subscriptionId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+    when(profileDao.getBillingProfileById(profile.id())).thenReturn(profile);
+
+    profileService.deleteProfile(profile.id(), userRequest);
+    verify(applicationService).removeTagFromMrg(tenantId, subscriptionId, mrgId, "terra.billingProfileId");
+  }
+
+  @Test
+  void deletingGCPProfileDoesNotDoUnlinkMRGStep() {
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.GCP,
+            Optional.of("ABCDEF-1234"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            null,
+            null,
+            null);
+    when(profileDao.getBillingProfileById(profile.id())).thenReturn(profile);
+
+    profileService.deleteProfile(profile.id(), userRequest);
+    verify(applicationService, never()).removeTagFromMrg(any(), any(), any(), any());
+
+  }
+
+
+}

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
@@ -1,5 +1,8 @@
 package bio.terra.profile.service.profile.flight.delete;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
 import bio.terra.profile.common.BaseSpringUnitTest;
@@ -11,34 +14,22 @@ import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.profile.ProfileService;
 import bio.terra.profile.service.profile.model.BillingProfile;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
-
 public class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
-  @Autowired
-  ProfileService profileService;
-  @Autowired
-  AzureConfiguration azureConfiguration;
-  @MockBean
-  CrlService crlService;
+  @Autowired ProfileService profileService;
+  @Autowired AzureConfiguration azureConfiguration;
+  @MockBean CrlService crlService;
 
-  @MockBean
-  ProfileDao profileDao;
-  @MockBean
-  SamService samService;
-  @MockBean
-  AzureService azureService;
-  @MockBean
-  ApplicationService applicationService;
+  @MockBean ProfileDao profileDao;
+  @MockBean SamService samService;
+  @MockBean AzureService azureService;
+  @MockBean ApplicationService applicationService;
 
   AuthenticatedUserRequest userRequest =
       AuthenticatedUserRequest.builder()
@@ -46,7 +37,6 @@ public class DeleteProfileFlightTest extends BaseSpringUnitTest {
           .setSubjectId("fake-sub")
           .setEmail("example@example.com")
           .build();
-
 
   @Test
   void deletingAzureProfileUnlinksMRG() {
@@ -71,7 +61,8 @@ public class DeleteProfileFlightTest extends BaseSpringUnitTest {
     when(profileDao.getBillingProfileById(profile.id())).thenReturn(profile);
 
     profileService.deleteProfile(profile.id(), userRequest);
-    verify(applicationService).removeTagFromMrg(tenantId, subscriptionId, mrgId, "terra.billingProfileId");
+    verify(applicationService)
+        .removeTagFromMrg(tenantId, subscriptionId, mrgId, "terra.billingProfileId");
   }
 
   @Test
@@ -94,8 +85,5 @@ public class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
     profileService.deleteProfile(profile.id(), userRequest);
     verify(applicationService, never()).removeTagFromMrg(any(), any(), any(), any());
-
   }
-
-
 }

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class DeleteProfileFlightTest extends BaseSpringUnitTest {
+class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
   @Autowired ProfileService profileService;
   @Autowired AzureConfiguration azureConfiguration;

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
@@ -13,6 +13,7 @@ import bio.terra.profile.service.azure.AzureService;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.iam.SamService;
 import bio.terra.profile.service.profile.ProfileService;
+import bio.terra.profile.service.profile.flight.MRGTags;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import java.util.Optional;
 import java.util.UUID;
@@ -62,7 +63,7 @@ class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
     profileService.deleteProfile(profile.id(), userRequest);
     verify(applicationService)
-        .removeTagFromMrg(tenantId, subscriptionId, mrgId, "terra.billingProfileId");
+        .removeTagFromMrg(tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStepUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/UnlinkBillingProfileIdFromMrgStepUnitTest.java
@@ -1,0 +1,79 @@
+package bio.terra.profile.service.profile.flight.delete;
+
+import static org.mockito.Mockito.*;
+
+import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.model.CloudPlatform;
+import bio.terra.profile.service.azure.ApplicationService;
+import bio.terra.profile.service.profile.flight.MRGTags;
+import bio.terra.profile.service.profile.model.BillingProfile;
+import bio.terra.stairway.FlightContext;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class UnlinkBillingProfileIdFromMrgStepUnitTest extends BaseUnitTest {
+
+  @Test
+  void unlinkingProfileStepRemovesTagFromMRG() throws Exception {
+    var tenantId = UUID.randomUUID();
+    var subscriptionId = UUID.randomUUID();
+    var mrgId = "test-MRG-ID";
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.of("ABCDEF-1234"),
+            Optional.of(tenantId),
+            Optional.of(subscriptionId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+    ApplicationService applicationService = mock(ApplicationService.class);
+
+    var step = new UnlinkBillingProfileIdFromMrgStep(applicationService, profile);
+
+    var flightContext = mock(FlightContext.class);
+    step.doStep(flightContext);
+
+    verify(applicationService)
+        .removeTagFromMrg(tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID);
+  }
+
+  @Test
+  void undoStepForAzureProfileRelinksMRG() throws Exception {
+    var tenantId = UUID.randomUUID();
+    var subscriptionId = UUID.randomUUID();
+    var mrgId = "test-MRG-ID";
+
+    var profile =
+        new BillingProfile(
+            UUID.randomUUID(),
+            "fake-bp-name",
+            "fake-description",
+            "direct",
+            CloudPlatform.AZURE,
+            Optional.of("ABCDEF-1234"),
+            Optional.of(tenantId),
+            Optional.of(subscriptionId),
+            Optional.of(mrgId),
+            null,
+            null,
+            null);
+    ApplicationService applicationService = mock(ApplicationService.class);
+
+    var step = new UnlinkBillingProfileIdFromMrgStep(applicationService, profile);
+
+    var flightContext = mock(FlightContext.class);
+    step.undoStep(flightContext);
+
+    verify(applicationService)
+        .addTagToMrg(
+            tenantId, subscriptionId, mrgId, MRGTags.BILLING_PROFILE_ID, profile.id().toString());
+  }
+}


### PR DESCRIPTION
[WOR-634](https://broadworkbench.atlassian.net/browse/WOR-634)

* Adds a step to unlink the MRG in the billing profile delete flight 
* Unlink MRG in the undo step of linking an MRG

On the develop branch, when I create a billing profile, delete it, and then try to create a new billing profile re-using the same MRG, I get a 409 back with the error message: `"MRG has existing tag [mrg_id = ..., existing tag = terra.billingProfileId, value =...]"`

After the changes, the above process succeeds.