### PR TITLE
Allow spring-boot to continue with 2.x releases (WOR-652).

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       - "gradle"
     commit-message:
       prefix: "[No Ticket]"
+    ignore:
+      - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
+        versions: ["3.x"]


### PR DESCRIPTION
We have deferred upgrading spring-boot to 3.x (WOR-649), but should continue allowing 2.x upgrades. In particular, there is a 2.7.6 release, and I'm hoping this change allows dependabot to offer it.

Ignore syntax: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore