### PR TITLE
Enable micrometer and actuator (WOR-547).

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -18,5 +18,8 @@ dependencies {
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.7.5'
     implementation 'bio.terra:terra-test-runner:0.1.8-SNAPSHOT'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.6'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.8.6'
+
 }
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -53,6 +53,12 @@ spring:
         use-last-modified: false
       static-locations: classpath:/api/
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
 profile:
   ingress:
     # Default value that's overridden by Helm.


### PR DESCRIPTION
Following the lead of https://github.com/DataBiosphere/jade-data-repo/pull/768 and a [tutorial](https://www.tutorialworks.com/spring-boot-prometheus-micrometer/).

Note that this will just provide default metrics like JVM heap size. We can choose to add custom metrics later, but I would like to get the integration with prometheus working first.

After this is merged, I will experiment with how to scrape the data into prometheus. Muscles said this took some experimentation and devops help.