### PR TITLE
Add metric namespace (WOR-547).

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/common/MetricUtils.java
+++ b/service/src/main/java/bio/terra/profile/app/common/MetricUtils.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Callable;
 
 public class MetricUtils {
 
+  private static final String NAMESPACE = "bpm";
   private static final String CLOUD_PLATFORM_TAG = "cloudPlatform";
 
   /**
@@ -19,7 +20,10 @@ public class MetricUtils {
       Callable<BillingProfile> callable, CloudPlatform platform) {
     try {
       return Metrics.globalRegistry
-          .timer("profile.creation.time", CLOUD_PLATFORM_TAG, platform.toString())
+          .timer(
+              String.format("%s.profile.creation.time", NAMESPACE),
+              CLOUD_PLATFORM_TAG,
+              platform.toString())
           .recordCallable(callable);
     } catch (RuntimeException ex) {
       // The method we are calling does not throw checked exceptions, so retain the original.
@@ -37,7 +41,10 @@ public class MetricUtils {
    */
   public static void incrementProfileDeletion(CloudPlatform platform) {
     Metrics.globalRegistry
-        .counter("profile.deletion.count", CLOUD_PLATFORM_TAG, platform.toString())
+        .counter(
+            String.format("%s.profile.deletion.count", NAMESPACE),
+            CLOUD_PLATFORM_TAG,
+            platform.toString())
         .increment();
   }
 }

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -88,7 +88,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
     assertNotNull(createdProfile.lastModified());
     assertEquals(createdProfile.createdBy(), userRequest.getEmail());
 
-    var timer = meterRegistry.find("profile.creation.time").timer();
+    var timer = meterRegistry.find("bpm.profile.creation.time").timer();
     assertNotNull(timer);
     assertEquals(timer.count(), 1);
     assertEquals(timer.getId().getTag("cloudPlatform"), CloudPlatform.GCP.toString());
@@ -175,7 +175,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
         .addTagToMrg(tenantId, subId, mrgId, "terra.billingProfileId", profile.id().toString());
     verify(samService).createManagedResourceGroup(profile, userRequest);
 
-    var timer = meterRegistry.find("profile.creation.time").timer();
+    var timer = meterRegistry.find("bpm.profile.creation.time").timer();
     assertNotNull(timer);
     assertEquals(timer.count(), 1);
     assertEquals(timer.getId().getTag("cloudPlatform"), CloudPlatform.AZURE.toString());

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
@@ -96,7 +96,7 @@ class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
     var azureCounter =
         meterRegistry
-            .find("profile.deletion.count")
+            .find("bpm.profile.deletion.count")
             .tags("cloudPlatform", CloudPlatform.AZURE.toString())
             .counter();
     assertNotNull(azureCounter);
@@ -104,7 +104,7 @@ class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
     var gcpCounter =
         meterRegistry
-            .find("profile.deletion.count")
+            .find("bpm.profile.deletion.count")
             .tags("cloudPlatform", CloudPlatform.GCP.toString())
             .counter();
     assertNotNull(gcpCounter);


### PR DESCRIPTION
Metrics need to start with their service name so they can potentially mix together on dashboards. [Slack conversation](https://broadinstitute.slack.com/archives/CADM7MZ35/p1670618699464539) with Jack.