### PR TITLE
[DDO-2529] Deploy merged versions to Broad's dev env, the new way

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,14 +67,6 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
 
-      - name: Deploy to Terra Dev environment
-        uses: broadinstitute/repository-dispatch@master
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          repository: broadinstitute/terra-helmfile
-          event-type: update-service
-          client-payload: '{"service": "bpm", "version": "${{ needs.tag.outputs.tag }}", "dev_only": false}'
-
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0
         if: failure()
@@ -85,3 +77,27 @@ jobs:
           author_name: Publish to dev
           fields: job
           text: 'Publish failed :sadpanda:'
+
+  report-to-sherlock:
+    # Report new BPM version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [tag, publish-job]
+    with:
+      new-version: ${{ needs.tag.outputs.tag }}
+      chart-name: 'bpm'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  set-version-in-dev:
+    # Put new BPM version in Broad dev environment
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [tag, publish-job, report-to-sherlock]
+    with:
+      new-version: ${{ needs.tag.outputs.tag }}
+      chart-name: 'bpm'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'


### PR DESCRIPTION
Pretty much the same thing I did for WSM in https://github.com/DataBiosphere/terra-workspace-manager/pull/953

The behavior is a superset of the old behavior. The old behavior was "put v1.2.3 in dev". The new behavior is "tell devops about v1.2.3 including git info, put v1.2.3 in dev, then sync dev so it gets deployed immediately".

The "tell devops" step gives Sherlock a _ton_ more info to play with than the old mechanism this PR removes: we can show better accelerate metrics in Grafana and auto-generate changelogs in Beehive.

> **Note**
> There's an implementation change here beyond just "talk to Sherlock directly." The old mechanism fired off a dispatch to terra-helmfile and exited--pretty opaque from everyone's perspective except devops, at least at first glance.
>
> The new mechanism leverages re-usable workflows where possible, so the code that runs is still defined once, but GitHub Actions can understand the behavior better. That means that you might see [a flowchart like this](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/3688913109) if you click on a run of this action going forward. It also means that devops can [keep better track of the dependents on this behavior](https://github.com/broadinstitute/sherlock/network/dependents?package_id=UGFja2FnZS0zNDE5NTc1ODk5) in case we ever need to make call-side changes down the line.