### PR TITLE
[WOR-678] add pet-creator policy with pet-creator role to new spend-profiles

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -309,6 +309,10 @@ public class SamService {
         SamRole.USER.getSamRoleName(),
         new AccessPolicyMembershipV2().addRolesItem(SamRole.USER.getSamRoleName()));
 
+    policyMap.put(
+        SamRole.PET_CREATOR.getSamRoleName(),
+        new AccessPolicyMembershipV2().addRolesItem(SamRole.PET_CREATOR.getSamRoleName()));
+
     CreateResourceRequestV2 profileRequest =
         new CreateResourceRequestV2()
             .resourceId(profileId.toString())

--- a/service/src/main/java/bio/terra/profile/service/iam/model/SamRole.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/model/SamRole.java
@@ -7,7 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 public enum SamRole {
   ADMIN("admin"),
   OWNER("owner"),
-  USER("user");
+  USER("user"),
+  PET_CREATOR("pet-creator");
 
   private final String samRoleName;
 


### PR DESCRIPTION
Ticket: [WOR-678](https://broadworkbench.atlassian.net/browse/WOR-678)
- Create empty pet-creator policy when creating new spend-profile resources in Sam. 
- Rawls will add new workspace writers to this policy
- We will not migrate existing spend-profile resources at this time

[WOR-678]: https://broadworkbench.atlassian.net/browse/WOR-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ