### PR TITLE
[WOR-729] Trim whitespace when parsing the list of authed user emails

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -138,7 +138,8 @@ public class AzureService {
       var paramValues = (Map) rawParams.get(authedUserKey);
       var authedUsers = ((String) paramValues.get("value")).split(",");
 
-      return Arrays.stream(authedUsers).anyMatch(user -> user.trim().equals(userRequest.getEmail()));
+      return Arrays.stream(authedUsers)
+          .anyMatch(user -> user.trim().equals(userRequest.getEmail()));
     }
 
     return false;

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -138,7 +138,7 @@ public class AzureService {
       var paramValues = (Map) rawParams.get(authedUserKey);
       var authedUsers = ((String) paramValues.get("value")).split(",");
 
-      return Arrays.stream(authedUsers).anyMatch(user -> user.equals(userRequest.getEmail()));
+      return Arrays.stream(authedUsers).anyMatch(user -> user.trim().equals(userRequest.getEmail()));
     }
 
     return false;

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -222,12 +222,12 @@ public class AzureServiceUnitTest extends BaseUnitTest {
   public void getManagedApps_handlesMultipleEmails() {
     var authedTerraApp = mock(Application.class);
     mockApplicationCalls(
-            authedTerraApp,
-            offerName,
-            offerPublisher,
-            Optional.of("foo@bar.com, " + authedUserEmail),
-            "mrg_fake1",
-            "fake_app_1");
+        authedTerraApp,
+        offerName,
+        offerPublisher,
+        Optional.of("foo@bar.com, " + authedUserEmail),
+        "mrg_fake1",
+        "fake_app_1");
 
     var appsList = Stream.of(authedTerraApp);
     var appService = mock(ApplicationService.class);
@@ -243,23 +243,23 @@ public class AzureServiceUnitTest extends BaseUnitTest {
     offer.setAuthorizedUserKey(authorizedUserKey);
     var offers = Set.of(offer);
     var azureService =
-            new AzureService(
-                    crlService,
-                    appService,
-                    new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()),
-                    profileDao);
+        new AzureService(
+            crlService,
+            appService,
+            new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()),
+            profileDao);
 
     var result = azureService.getAuthorizedManagedAppDeployments(subId, true, user);
 
     var expected =
-            List.of(
-                    new AzureManagedAppModel()
-                            .applicationDeploymentName("fake_app_1")
-                            .tenantId(tenantId)
-                            .managedResourceGroupId("mrg_fake1")
-                            .subscriptionId(subId)
-                            .assigned(false)
-                            .region(regionName));
+        List.of(
+            new AzureManagedAppModel()
+                .applicationDeploymentName("fake_app_1")
+                .tenantId(tenantId)
+                .managedResourceGroupId("mrg_fake1")
+                .subscriptionId(subId)
+                .assigned(false)
+                .region(regionName));
     assertEquals(result, expected);
   }
 


### PR DESCRIPTION
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-729)
I bumped into this in my testing just now against the prod offer; BPM does not trim whitespace when presented with a CSV of authorized terra users in an offer.