### PR TITLE
[WOR-507] Set no-store Cache-Control header on all authenticated APIs

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/Main.java
+++ b/service/src/main/java/bio/terra/profile/app/Main.java
@@ -33,9 +33,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
       "bio.terra.profile"
     })
 @ConfigurationPropertiesScan(basePackages = {"bio.terra.profile"})
+@ServletComponentScan(basePackages = {"bio.terra.profile"})
 @EnableRetry
 @EnableTransactionManagement
-@ServletComponentScan
 public class Main {
   public static void main(String[] args) {
     new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);

--- a/service/src/main/java/bio/terra/profile/app/Main.java
+++ b/service/src/main/java/bio/terra/profile/app/Main.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @ConfigurationPropertiesScan(basePackages = {"bio.terra.profile"})
 @EnableRetry
 @EnableTransactionManagement
+@ServletComponentScan
 public class Main {
   public static void main(String[] args) {
     new SpringApplicationBuilder(Main.class).initializers(new LoggingInitializer()).run(args);

--- a/service/src/main/java/bio/terra/profile/app/configuration/NoCacheFilter.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/NoCacheFilter.java
@@ -5,8 +5,7 @@ import javax.servlet.*;
 import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletResponse;
 
-@WebFilter(
-    urlPatterns = {"/api/azure/v1/managedApps", "/api/profiles/v1", "/api/profiles/v1/{profileId}"})
+@WebFilter(urlPatterns = {"/api/*"})
 public class NoCacheFilter implements Filter {
 
   @Override

--- a/service/src/main/java/bio/terra/profile/app/configuration/NoCacheFilter.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/NoCacheFilter.java
@@ -13,7 +13,7 @@ public class NoCacheFilter implements Filter {
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
     var servletResponse = (HttpServletResponse) response;
-    servletResponse.setHeader("Cache-Control", "no-cache");
+    servletResponse.setHeader("Cache-Control", "no-store");
     chain.doFilter(request, response);
   }
 }

--- a/service/src/main/java/bio/terra/profile/app/configuration/NoCacheFilter.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/NoCacheFilter.java
@@ -1,0 +1,19 @@
+package bio.terra.profile.app.configuration;
+
+import java.io.IOException;
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletResponse;
+
+@WebFilter(
+    urlPatterns = {"/api/azure/v1/managedApps", "/api/profiles/v1", "/api/profiles/v1/{profileId}"})
+public class NoCacheFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    var servletResponse = (HttpServletResponse) response;
+    servletResponse.setHeader("Cache-Control", "no-cache");
+    chain.doFilter(request, response);
+  }
+}


### PR DESCRIPTION
Ticket: [WOR-507](https://broadworkbench.atlassian.net/browse/WOR-507)
* set cache-control header to `no-store` so that browsers will not cache the returned content. This header is set only on `/api/*` endpoints as it is not needed for unauthenticated requests


Before:
```
curl -X GET 'http://localhost:8080/api/profiles/v1?offset=0&limit=10' --header "Authorization: Bearer `gcloud auth print-access-token marc.testbott@gmail.com`" -i
HTTP/1.1 200 
X-Request-ID: axzk5MzR
Content-Type: application/json
Content-Length: 481
```

After:
```
curl -X GET 'http://localhost:8080/api/profiles/v1?offset=0&limit=10' --header "Authorization: Bearer `gcloud auth print-access-token marc.testbott@gmail.com`" -i                                                            
HTTP/1.1 200 
Cache-Control: no-store
X-Request-ID: ey3KL2Xj
Content-Type: application/json
Content-Length: 481
```

Note that the reason there are fewer headers shown here is because I grabbed the output from a locally running BPM and additional headers (like you may see in the ticket description) are added when it's running in k8s by the proxy presumably

[WOR-507]: https://broadworkbench.atlassian.net/browse/WOR-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ