### PR TITLE
[WOR-767] Handle management exceptions for inaccessible Azure subscriptions

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -16,7 +16,7 @@ public class ApplicationService {
   public static final String AZURE_AUTH_FAILED = "AuthorizationFailed";
   public static final String INVALID_AUTH_TOKEN = "InvalidAuthenticationTokenTenant";
 
-  private static final Set<String> INACCCESSIBLE_SUB_CODES =
+  private static final Set<String> INACCESSIBLE_SUB_CODES =
       Set.of(AZURE_SUB_NOT_FOUND, AZURE_AUTH_FAILED, INVALID_AUTH_TOKEN);
 
   private final CrlService crlService;
@@ -48,7 +48,7 @@ public class ApplicationService {
     try {
       return crlService.getTenantForSubscription(subscriptionId);
     } catch (ManagementException e) {
-      if (INACCCESSIBLE_SUB_CODES.contains(e.getValue().getCode())) {
+      if (INACCESSIBLE_SUB_CODES.contains(e.getValue().getCode())) {
         throw new InaccessibleSubscriptionException("Subscription not accessible", e);
       }
       throw e;

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -1,16 +1,24 @@
 package bio.terra.profile.service.azure;
 
+import bio.terra.profile.service.azure.exception.InaccessibleSubscriptionException;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.DuplicateTagException;
+import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.managedapplications.models.Application;
-import java.util.HashMap;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ApplicationService {
+  public static final String AZURE_SUB_NOT_FOUND = "SubscriptionNotFound";
+  public static final String AZURE_AUTH_FAILED = "AuthorizationFailed";
+  public static final String INVALID_AUTH_TOKEN = "InvalidAuthenticationTokenTenant";
+
+  private static final Set<String> INACCCESSIBLE_SUB_CODES =
+      Set.of(AZURE_SUB_NOT_FOUND, AZURE_AUTH_FAILED, INVALID_AUTH_TOKEN);
+
   private final CrlService crlService;
 
   @Autowired
@@ -34,9 +42,17 @@ public class ApplicationService {
    *
    * @param subscriptionId Azure subscription ID to be queried
    * @return UUID for the associated tenant
+   * @throws InaccessibleSubscriptionException when the azure subscription is not accessible by BPM
    */
   public UUID getTenantForSubscription(UUID subscriptionId) {
-    return crlService.getTenantForSubscription(subscriptionId);
+    try {
+      return crlService.getTenantForSubscription(subscriptionId);
+    } catch (ManagementException e) {
+      if (INACCCESSIBLE_SUB_CODES.contains(e.getValue().getCode())) {
+        throw new InaccessibleSubscriptionException("Subscription not accessible", e);
+      }
+      throw e;
+    }
   }
 
   /**

--- a/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/ApplicationService.java
@@ -4,7 +4,6 @@ import bio.terra.profile.service.azure.exception.InaccessibleSubscriptionExcepti
 import bio.terra.profile.service.crl.CrlService;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.managedapplications.models.Application;
-
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;

--- a/service/src/main/java/bio/terra/profile/service/azure/exception/InaccessibleSubscriptionException.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/exception/InaccessibleSubscriptionException.java
@@ -1,0 +1,9 @@
+package bio.terra.profile.service.azure.exception;
+
+import bio.terra.common.exception.NotFoundException;
+
+public class InaccessibleSubscriptionException extends NotFoundException {
+  public InaccessibleSubscriptionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -4,14 +4,57 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.service.azure.exception.InaccessibleSubscriptionException;
 import bio.terra.profile.service.crl.CrlService;
 import bio.terra.profile.service.profile.exception.DuplicateTagException;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.resources.models.ResourceGroup;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class ApplicationServiceUnitTest extends BaseUnitTest {
+  @Test
+  void getTenantForSubscription_accessibleSubscription() {
+    var crlService = mock(CrlService.class);
+    var expectedTenantId = UUID.randomUUID();
+    when(crlService.getTenantForSubscription(any(UUID.class))).thenReturn(expectedTenantId);
+    var applicationService = new ApplicationService(crlService);
+
+    var result = applicationService.getTenantForSubscription(UUID.randomUUID());
+
+    assert (result.equals(expectedTenantId));
+  }
+
+  @Test
+  void getTenantForSubscription_inaccessibleSubscription() {
+    var crlService = mock(CrlService.class);
+    when(crlService.getTenantForSubscription(any(UUID.class)))
+        .thenThrow(
+            new ManagementException(
+                "error",
+                null,
+                new ManagementError(ApplicationService.AZURE_SUB_NOT_FOUND, "not found")));
+    var applicationService = new ApplicationService(crlService);
+
+    assertThrows(
+        InaccessibleSubscriptionException.class,
+        () -> applicationService.getTenantForSubscription(UUID.randomUUID()));
+  }
+
+  @Test
+  void getTenantForSubscription_otherMgmtError() {
+    var crlService = mock(CrlService.class);
+    when(crlService.getTenantForSubscription(any(UUID.class)))
+        .thenThrow(
+            new ManagementException("error", null, new ManagementError("ExampleError", "example")));
+    var applicationService = new ApplicationService(crlService);
+
+    assertThrows(
+        ManagementException.class,
+        () -> applicationService.getTenantForSubscription(UUID.randomUUID()));
+  }
 
   @Test
   void addTagToMrg() {

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -6,11 +6,8 @@ import static org.mockito.Mockito.*;
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.service.azure.exception.InaccessibleSubscriptionException;
 import bio.terra.profile.service.crl.CrlService;
-import bio.terra.profile.service.profile.exception.DuplicateTagException;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
-import com.azure.resourcemanager.resources.models.ResourceGroup;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 

--- a/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/ApplicationServiceUnitTest.java
@@ -1,5 +1,6 @@
 package bio.terra.profile.service.azure;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -21,7 +22,7 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
 
     var result = applicationService.getTenantForSubscription(UUID.randomUUID());
 
-    assert (result.equals(expectedTenantId));
+    assertEquals(result, expectedTenantId);
   }
 
   @Test
@@ -34,10 +35,11 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
                 null,
                 new ManagementError(ApplicationService.AZURE_SUB_NOT_FOUND, "not found")));
     var applicationService = new ApplicationService(crlService);
+    var testUuid = UUID.randomUUID();
 
     assertThrows(
         InaccessibleSubscriptionException.class,
-        () -> applicationService.getTenantForSubscription(UUID.randomUUID()));
+        () -> applicationService.getTenantForSubscription(testUuid));
   }
 
   @Test
@@ -47,9 +49,9 @@ class ApplicationServiceUnitTest extends BaseUnitTest {
         .thenThrow(
             new ManagementException("error", null, new ManagementError("ExampleError", "example")));
     var applicationService = new ApplicationService(crlService);
+    var testUuid = UUID.randomUUID();
 
     assertThrows(
-        ManagementException.class,
-        () -> applicationService.getTenantForSubscription(UUID.randomUUID()));
+        ManagementException.class, () -> applicationService.getTenantForSubscription(testUuid));
   }
 }


### PR DESCRIPTION
[Relevant ticket](https://broadworkbench.atlassian.net/browse/WOR-767)

BPM will 500 attempting to inspect a subscription for managed app deployments. This PR catches the related management exceptions and instead returns 404. The cause will still be logged for further diagnostics if necessary. 