### PR TITLE
[WOR-714] Bump cloud-resource-library version

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -37,11 +37,7 @@ dependencies {
 	implementation group: "com.azure.resourcemanager", name: "azure-resourcemanager-managedapplications", version: "1.0.0-beta.2"
 	implementation group: "com.azure.resourcemanager", name: "azure-resourcemanager-subscription", version: "1.0.0-beta.2"
 
-
-	// TODO: remove SNAPSHOT once https://github.com/DataBiosphere/terra-cloud-resource-lib/pull/109 is merged
-	implementation platform('bio.terra.cloud-resource-lib:platform:0.8.2-SNAPSHOT')
-	implementation group: 'bio.terra.cloud-resource-lib', name: 'google-billing'
-	implementation group: 'bio.terra.cloud-resource-lib', name: 'azure-resourcemanager-common'
+	implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.7-SNAPSHOT"
 
 	// Sam
 	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-e0d8da8"


### PR DESCRIPTION
Ticket: [WOR-714](https://broadworkbench.atlassian.net/browse/WOR-714)

- Tested by attempting to create a GCP billing profile with two different users, one with access to the Google billing account and one without. `CreateProfileVerifyAccountStep` (what uses the GCP billing CRL library) failed as expected for the user without access and succeeded for the one that did. 

[WOR-714]: https://broadworkbench.atlassian.net/browse/WOR-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ