### PR TITLE
[WOR-892] Do not dispatch tag if this is a version bump

### DIFF
--- a/.github/actions/bump-skip/action.yml
+++ b/.github/actions/bump-skip/action.yml
@@ -1,0 +1,28 @@
+# This action must be done after the checkout action
+name: 'bump-skip'
+description: 'Set skip-out when we are doing a version bump'
+author: 'dd'
+inputs:
+  event-name:
+    description: 'github.event_name from the calling workflow'
+    required: true
+outputs:
+  is-bump:
+    description: 'yes if this is a push made by bumper; no if it is a regular push'
+    value: ${{ steps.bumptest.outputs.is-bump }}
+runs:
+  using: "composite"
+  steps:
+    - name: Bump test
+      id: bumptest
+      run: |
+        log=$(git log --pretty='%B')
+        echo "log=$log"
+        pattern="^bump .*"
+        IS_BUMP=no
+        if [[ "${{ inputs.event-name }}" == "push" && "$log" =~ $pattern ]]; then
+          IS_BUMP=yes
+        fi
+        echo "IS_BUMP=$IS_BUMP"
+        echo ::set-output name=is-bump::$IS_BUMP
+      shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+
       - name: Gradle cache
         uses: actions/cache@v2
         with:
@@ -48,6 +49,7 @@ jobs:
           sarif_file: service/build/reports/spotbugs/main.sarif
 
   jib:
+    name: Build Docker image
     needs: [ build ]
     runs-on: ubuntu-latest
 
@@ -74,6 +76,7 @@ jobs:
           -Djib.console=plain
 
   unit-tests:
+    name: Run unit tests
     needs: [ build ]
     runs-on: ubuntu-latest
 
@@ -124,6 +127,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify-slack:
+    name: Notify Slack
     needs: [ build, jib, unit-tests ]
     runs-on: ubuntu-latest
 
@@ -141,11 +145,24 @@ jobs:
           fields: workflow,message
           text: 'Build failed :sadpanda:'
 
-  dispatch-tag:
-    needs: [ build, jib, unit-tests ]
+  bump-check:
+    name: Check if version bump
     runs-on: ubuntu-latest
+    outputs:
+      is-bump: ${{ steps.skiptest.outputs.is-bump }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Skip version bump merges
+        id: skiptest
+        uses: ./.github/actions/bump-skip
+        with:
+          event-name: ${{ github.event_name }}
 
-    if: success() && github.ref == 'refs/heads/main'
+  dispatch-tag:
+    name: Dispatch tag, publish and deploy
+    needs: [ build, jib, unit-tests, bump-check ]
+    runs-on: ubuntu-latest
+    if: success() &&  needs.bump-check.outputs.is-bump == 'no' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Fire off publish action

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,7 +123,7 @@ jobs:
         run: ./gradlew --build-cache test jacocoTestReport
 
       - name: SonarQube scan
-        run: ./gradlew --build-cache sonarqube
+        run: ./gradlew --build-cache sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,6 @@ jobs:
           sarif_file: service/build/reports/spotbugs/main.sarif
 
   jib:
-    name: Build Docker image
     needs: [ build ]
     runs-on: ubuntu-latest
 
@@ -76,7 +75,6 @@ jobs:
           -Djib.console=plain
 
   unit-tests:
-    name: Run unit tests
     needs: [ build ]
     runs-on: ubuntu-latest
 
@@ -89,6 +87,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        # Needed by sonar to get the git history for the branch the PR will be merged into.
+        with:
+          fetch-depth: 0
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -127,7 +129,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify-slack:
-    name: Notify Slack
     needs: [ build, jib, unit-tests ]
     runs-on: ubuntu-latest
 
@@ -146,7 +147,6 @@ jobs:
           text: 'Build failed :sadpanda:'
 
   bump-check:
-    name: Check if version bump
     runs-on: ubuntu-latest
     outputs:
       is-bump: ${{ steps.skiptest.outputs.is-bump }}
@@ -159,7 +159,6 @@ jobs:
           event-name: ${{ github.event_name }}
 
   dispatch-tag:
-    name: Dispatch tag, publish and deploy
     needs: [ build, jib, unit-tests, bump-check ]
     runs-on: ubuntu-latest
     if: success() &&  needs.bump-check.outputs.is-bump == 'no' && github.ref == 'refs/heads/main'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -88,16 +88,17 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pact-b64": "${{ needs.bpm-consumer-contract-tests.outputs.pact-b64 }}", "repo-owner": "${{ github.repository_owner }}", "repo-name": "${{ github.event.repository.name }}", "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}" }'
 
-  can-i-deploy:
-    runs-on: ubuntu-latest
-    needs: [ init-github-context, publish-contracts ]
-    steps:
-      - name: Dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
-        with:
-          workflow: .github/workflows/can-i-deploy.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "bpm-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}" }'
+## Deactivated until WOR-890 lands
+#  can-i-deploy:
+#    runs-on: ubuntu-latest
+#    needs: [ init-github-context, publish-contracts ]
+#    steps:
+#      - name: Dispatch to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v3
+#        with:
+#          workflow: .github/workflows/can-i-deploy.yaml
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+#          inputs: '{ "pacticipant": "bpm-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}" }'
 


### PR DESCRIPTION
We erroneously fire off a tag+publish+deploy on version bumps, which means we are attempting to tag+publish+deploy the same version twice which [results](https://github.com/DataBiosphere/terra-billing-profile-manager/actions/workflows/publish.yml) in a 409 in sherlock. This PR adds a check for version bump merges.