### PR TITLE
widen dependabot exclusion scope to cover all pact libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,5 @@ updates:
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "au.com.dius.pact.consumer:junit5"
+      - dependency-name: "au.com.dius.pact*"
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
[WOR-891](https://broadworkbench.atlassian.net/browse/WOR-891)

We don't want dependabot to upgrade any of the pact libs

[WOR-891]: https://broadworkbench.atlassian.net/browse/WOR-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ