### PR TITLE
[WOR-981] Increase flight retention interval

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -136,7 +136,7 @@ terra.common:
     terminate-timeout: 30s
     tracing-enabled: true
     retention-check-interval: 1d
-    completed-flight-retention: 7d
+    completed-flight-retention: 90d
 
   tracing:
     stackdriverExportEnabled: ${env.tracing.exportEnabled}


### PR DESCRIPTION
We should retain stairway flight records for at least 90 days for diagnostic purposes.