### PR TITLE
WOR-890 follow up on Sam consumer tests

### DIFF
--- a/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
@@ -44,7 +44,6 @@ public class SamServiceTest extends BaseUnitTest {
         .uponReceiving("a request for the user's status")
         .path("/register/user/v2/self/info")
         .method("GET")
-        .matchHeader("Authorization", "Bearer .+")
         .willRespondWith()
         .status(200)
         .body(userResponseShape)


### PR DESCRIPTION
[WOR-890](https://broadworkbench.atlassian.net/browse/WOR-890)

remove auth header from pact setup

Authentication is out of scope for what we're testing in pact. 
The header was originally added to the things checked in the pact setup in the early stages of implementation.

[WOR-890]: https://broadworkbench.atlassian.net/browse/WOR-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ