### PR TITLE
[WOR-1001] Bump tcl and terra-test-runner

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.0'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.7.11'
-    implementation 'bio.terra:terra-test-runner:0.1.8-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.1.9-SNAPSHOT'
 }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 		}
 		because 'previous versions have a security vulnerability - this is a direct dependency to force the version to override opencensus'
 	}
-	implementation 'bio.terra:terra-common-lib:0.0.77-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:0.0.88-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'


### PR DESCRIPTION
Ticket: [WOR-1001](https://broadworkbench.atlassian.net/browse/WOR-1001)
* new versions of TCL and terra-test-runner use 0.9.3 of jose4j
<img width="375" alt="Screenshot 2023-05-17 at 3 34 11 PM" src="https://github.com/DataBiosphere/terra-billing-profile-manager/assets/19961550/7b6ac859-eadb-4b19-8569-4efb49db46da">


[WOR-1001]: https://broadworkbench.atlassian.net/browse/WOR-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ