### PR TITLE
[WOR-1036] Update dependabot cadence to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ updates:
   # Enable version updates for Gradle
   - package-ecosystem: "gradle"
     directory: "/"
+    open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/New_York"
     target-branch: "main"
     reviewers:
       - "@DataBiosphere/broadworkspaces"


### PR DESCRIPTION
Similar to [LZS](https://github.com/DataBiosphere/terra-landing-zone-service/pull/140), this PR adjusts the dependabot cadence to weekly to reduce the captaincy burden. 