### PR TITLE
[WOR-1036] Output build report

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,7 +120,7 @@ jobs:
           psql -h localhost -U postgres -f ./service/local-dev/local-postgres-init.sql
 
       - name: Test with coverage
-        run: ./gradlew --build-cache test jacocoTestReport
+        run: ./gradlew --build-cache test jacocoTestReport --scan
 
       - name: SonarQube scan
         run: ./gradlew --build-cache sonar
@@ -140,7 +140,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.BPM_SLACK_WEBHOOK }}
         with:
-          channel: '#terra-billing-profile-manager'
+          channel: '#dsp-workspace-test-alerts'
           status: failure
           author_name: Build on dev
           fields: workflow,message

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -58,6 +58,14 @@ tasks.named('test') {
 version = gradle.releaseVersion
 group = 'bio.terra'
 
+// for scans
+if (hasProperty("buildScan")) {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}
+
 spotless {
     java {
         targetExclude "${buildDir}/**"


### PR DESCRIPTION
* We should get a test and build report so we can get more details about test failures.
* Test failures should go to # dsp-workspace-test-alerts