### PR TITLE
QA-2075: Add state and http header to user status info request.

### DIFF
--- a/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
@@ -40,9 +40,11 @@ public class SamServiceTest {
             .stringType("userEmail")
             .booleanType("enabled");
     return builder
+            .given("user status info request with access token")
         .uponReceiving("a request for the user's status")
         .path("/register/user/v2/self/info")
         .method("GET")
+            .headers("Authorization", "Bearer accessToken")
         .willRespondWith()
         .status(200)
         .body(userResponseShape)

--- a/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
@@ -40,11 +40,11 @@ public class SamServiceTest {
             .stringType("userEmail")
             .booleanType("enabled");
     return builder
-            .given("user status info request with access token")
+        .given("user status info request with access token")
         .uponReceiving("a request for the user's status")
         .path("/register/user/v2/self/info")
         .method("GET")
-            .headers("Authorization", "Bearer accessToken")
+        .headers("Authorization", "Bearer accessToken")
         .willRespondWith()
         .status(200)
         .body(userResponseShape)


### PR DESCRIPTION
Jira ticket associated with this PR: [QA-2075](https://broadworkbench.atlassian.net/browse/QA-2075)

The Sam provider will support token vs no token states for user status info request.

Please also refer to this [PR](https://github.com/DataBiosphere/terra-workspace-data-service/pull/293).

[QA-2075]: https://broadworkbench.atlassian.net/browse/QA-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ