### PR TITLE
[WOR-1194] Set max header size to 32KB

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -37,6 +37,7 @@ spring.config.import: optional:file:build/resources/main/generated/local-propert
 logging.pattern.level: '%X{requestId} %5p'
 
 server:
+  max-http-header-size: 32KB
   compression:
     enabled: true
     mime-types: text/css,application/javascript


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1194)

Large access tokens exceed the default configured spring boot header size limit of 8k. I have not been able to reproduce this behavior using any available google accounts, but artificially lowering the spring max header size does reproduce the reported behavior.

This PR bumps the max header size to 32kb in an attempt to mitigate the issue. 