### PR TITLE
[WOR-1220] Microsoft.ManagedIdentity resource provider is required

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -120,6 +120,7 @@ profile:
       - "Microsoft.KeyVault"
       - "Microsoft.ContainerService"
       - "Microsoft.Relay"
+      - "Microsoft.ManagedIdentity"
 
   sentry:
     dsn: ${env.sentry.dsn}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1220

This came from a UL thread: https://broadinstitute.slack.com/archives/CBJJ7U293/p1692981855371259

The user was getting this error creating a BP:
```
Landing Zone creation failed: Failed to construct exception: com.azure.core.management.exception.ManagementException; Exception message: Status code 409, "{"error":{"code":"MissingSubscriptionRegistration","message":"The subscription is not registered to use namespace 'Microsoft.ManagedIdentity'. See https://aka.ms/rps-not-found for how to register subscriptions.","details":[{"code":"MissingSubscriptionRegistration","target":"Microsoft.ManagedIdentity","message":"The subscription is not registered to use namespace 'Microsoft.ManagedIdentity'. See https://aka.ms/rps-not-found for how to register subscriptions."}]}}"
```

I checked a few of our internal subscriptions and `Microsoft.ManagedIdentity` was enabled (which makes sense).