### PR TITLE
[PF-2972] Update dependencies to address security vulnerabilities

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,10 +13,18 @@ dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.21.0'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.3.2'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.5.0'
-    implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.5'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.3'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.3'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.7.15'
     implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
+
+    // Transitive dependency constraints due to security vulnerabilities in prior versions.
+    // These are not directly included, they are just constrained if they are pulled in as
+    // transitive dependencies.
+    constraints {
+        implementation('org.json:json:20230227')
+        implementation('org.graalvm.sdk:graal-sdk:22.3.2')
+    }
 }
 

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -44,6 +44,13 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-api:1.7.35'
 
+    // Transitive dependency constraints due to security vulnerabilities in prior versions.
+    // These are not directly included, they are just constrained if they are pulled in as
+    // transitive dependencies.
+    constraints {
+        spotbugs('org.apache.bcel:bcel:6.6.0')
+    }
+
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -44,13 +44,6 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-api:1.7.35'
 
-    // Transitive dependency constraints due to security vulnerabilities in prior versions.
-    // These are not directly included, they are just constrained if they are pulled in as
-    // transitive dependencies.
-    constraints {
-        spotbugs('org.apache.bcel:bcel:6.6.0')
-    }
-
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 		}
 		because 'previous versions have a security vulnerability - this is a direct dependency to force the version to override opencensus'
 	}
-	implementation 'bio.terra:terra-common-lib:0.0.88-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:0.0.94-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -44,7 +44,14 @@ dependencies {
 	implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.7-SNAPSHOT"
 
 	// Sam
-	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-e0d8da8"
+	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-fd8ee25"
+
+	// Transitive dependency constraints due to security vulnerabilities in prior versions.
+	// These are not directly included, they are just constrained if they are pulled in as
+	// transitive dependencies.
+	constraints {
+		implementation('org.json:json:20230227')
+	}
 
 	// Test deps
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -286,7 +286,7 @@ public class SamService {
       throws InterruptedException {
     ResourcesApi resourcesApi = samResourcesApi(userRequest.getToken());
 
-    Map<String, AccessPolicyMembershipV2> policyMap = new HashMap<>();
+    Map<String, AccessPolicyMembershipRequest> policyMap = new HashMap<>();
 
     // BPM-configured group has Admin role
     // TODO: configure admin group
@@ -299,18 +299,18 @@ public class SamService {
     // Calling user has Owner role
     policyMap.put(
         SamRole.OWNER.getSamRoleName(),
-        new AccessPolicyMembershipV2()
+        new AccessPolicyMembershipRequest()
             .addRolesItem(SamRole.OWNER.getSamRoleName())
             .addMemberEmailsItem(userRequest.getEmail()));
 
     // Create empty User policy which can be modified later
     policyMap.put(
         SamRole.USER.getSamRoleName(),
-        new AccessPolicyMembershipV2().addRolesItem(SamRole.USER.getSamRoleName()));
+        new AccessPolicyMembershipRequest().addRolesItem(SamRole.USER.getSamRoleName()));
 
     policyMap.put(
         SamRole.PET_CREATOR.getSamRoleName(),
-        new AccessPolicyMembershipV2().addRolesItem(SamRole.PET_CREATOR.getSamRoleName()));
+        new AccessPolicyMembershipRequest().addRolesItem(SamRole.PET_CREATOR.getSamRoleName()));
 
     CreateResourceRequestV2 profileRequest =
         new CreateResourceRequestV2()

--- a/service/src/main/java/bio/terra/profile/service/job/JobBuilder.java
+++ b/service/src/main/java/bio/terra/profile/service/job/JobBuilder.java
@@ -2,8 +2,8 @@ package bio.terra.profile.service.job;
 
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.common.stairway.MonitoringHook;
+import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.profile.app.common.MdcHook;
 import bio.terra.profile.service.job.exception.InvalidJobIdException;
 import bio.terra.profile.service.job.exception.InvalidJobParameterException;
@@ -105,7 +105,8 @@ public class JobBuilder {
     // Always add the MDC logging and tracing span parameters for the mdc hook
     addParameter(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
     addParameter(
-        MonitoringHook.SUBMISSION_SPAN_CONTEXT_MAP_KEY, MonitoringHook.serializeCurrentTracingContext());
+        MonitoringHook.SUBMISSION_SPAN_CONTEXT_MAP_KEY,
+        MonitoringHook.serializeCurrentTracingContext());
 
     // Convert the any other members that were set into parameters. However, if they were
     // explicitly added with addParameter during construction, we do not overwrite them.

--- a/service/src/main/java/bio/terra/profile/service/job/JobBuilder.java
+++ b/service/src/main/java/bio/terra/profile/service/job/JobBuilder.java
@@ -3,7 +3,7 @@ package bio.terra.profile.service.job;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.stairway.StairwayComponent;
-import bio.terra.common.stairway.TracingHook;
+import bio.terra.common.stairway.MonitoringHook;
 import bio.terra.profile.app.common.MdcHook;
 import bio.terra.profile.service.job.exception.InvalidJobIdException;
 import bio.terra.profile.service.job.exception.InvalidJobParameterException;
@@ -105,7 +105,7 @@ public class JobBuilder {
     // Always add the MDC logging and tracing span parameters for the mdc hook
     addParameter(MdcHook.MDC_FLIGHT_MAP_KEY, mdcHook.getSerializedCurrentContext());
     addParameter(
-        TracingHook.SUBMISSION_SPAN_CONTEXT_MAP_KEY, TracingHook.serializeCurrentTracingContext());
+        MonitoringHook.SUBMISSION_SPAN_CONTEXT_MAP_KEY, MonitoringHook.serializeCurrentTracingContext());
 
     // Convert the any other members that were set into parameters. However, if they were
     // explicitly added with addParameter during construction, we do not overwrite them.

--- a/service/src/main/java/bio/terra/profile/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/profile/service/job/JobService.java
@@ -1,8 +1,8 @@
 package bio.terra.profile.service.job;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.common.stairway.MonitoringHook;
+import bio.terra.common.stairway.StairwayComponent;
 import bio.terra.profile.app.common.ErrorReportUtils;
 import bio.terra.profile.app.common.MdcHook;
 import bio.terra.profile.app.configuration.IngressConfiguration;

--- a/service/src/main/java/bio/terra/profile/service/job/JobService.java
+++ b/service/src/main/java/bio/terra/profile/service/job/JobService.java
@@ -2,7 +2,7 @@ package bio.terra.profile.service.job;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.stairway.StairwayComponent;
-import bio.terra.common.stairway.TracingHook;
+import bio.terra.common.stairway.MonitoringHook;
 import bio.terra.profile.app.common.ErrorReportUtils;
 import bio.terra.profile.app.common.MdcHook;
 import bio.terra.profile.app.configuration.IngressConfiguration;
@@ -162,7 +162,7 @@ public class JobService {
             .dataSource(stairwayDatabaseConfiguration.getDataSource())
             .context(context)
             .addHook(mdcHook)
-            .addHook(new TracingHook())
+            .addHook(new MonitoringHook())
             .exceptionSerializer(new StairwayExceptionSerializer(objectMapper)));
   }
 


### PR DESCRIPTION
Verily security has started using a different dependency analysis tool which flagged a handful of vulnerabilities. I'd like to update dependencies to fix issues raised by both Verily's tool and Sourceclear.

I verified the dependency versions are changed by generating lockfiles locally, though it looks like this service generally isn't using them anymore so I didn't include them in this PR.