### PR TITLE
Use helmchart name for pact identifier.

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Output consumer contract as non-breaking base64 string
         id: encode-pact
         run: |
-          NON_BREAKING_B64=$(cat service/build/pacts/bpm-consumer-sam-provider.json | base64 -w 0)
+          NON_BREAKING_B64=$(cat service/build/pacts/bpm-sam.json | base64 -w 0)
           echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
   publish-contracts:
@@ -100,5 +100,4 @@ jobs:
 #          repo: broadinstitute/terra-github-workflows
 #          ref: refs/heads/main
 #          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-#          inputs: '{ "pacticipant": "bpm-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}" }'
-
+#          inputs: '{ "pacticipant": "bpm", "version": "${{ needs.init-github-context.outputs.repo-version }}" }'

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -212,4 +212,4 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "bpm-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'
+          inputs: '{ "pacticipant": "bpm", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'

--- a/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 @PactConsumerTest
 public class SamServiceTest {
 
-  @Pact(consumer = "bpm-consumer", provider = "sam-provider")
+  @Pact(consumer = "bpm", provider = "sam")
   public RequestResponsePact statusApiPact(PactDslWithProvider builder) {
     return builder
         .given("Sam is ok")
@@ -32,7 +32,7 @@ public class SamServiceTest {
         .toPact();
   }
 
-  @Pact(consumer = "bpm-consumer", provider = "sam-provider")
+  @Pact(consumer = "bpm", provider = "sam")
   public RequestResponsePact userStatusPact(PactDslWithProvider builder) {
     var userResponseShape =
         new PactDslJsonBody()

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -59,7 +59,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 @Tag("provider-test")
-@Provider("bpm-provider")
+@Provider("bpm")
 @PactBroker
 // for local testing, put any test pacts in the service/pacts folder.
 // then comment out the above line, and uncomment the following line


### PR DESCRIPTION
Prefer helmchart name as the pacticipant identifier:
* `bpm-provider` -> `bpm`
* `bpm-consumer` -> `bpm`
* `sam-provider` -> `sam`
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698068076950019) discussing the `-consumer` and `-provider` suffix anti-pattern.
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698241095600099) discussing the recommendation to use the helm chart name.

Unblocks:
* https://github.com/broadinstitute/rawls/pull/2610
* https://github.com/DataBiosphere/terra-workspace-manager/pull/1511
* https://github.com/broadinstitute/sam/pull/1234

Tickets:
[AJ-1428](https://broadworkbench.atlassian.net/browse/AJ-1428) - General maintenance ticket.
[AJ-1234](https://broadworkbench.atlassian.net/browse/AJ-1234) - Adjacent / similar, but not strictly dependent work.

[AJ-1428]: https://broadworkbench.atlassian.net/browse/AJ-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AJ-1234]: https://broadworkbench.atlassian.net/browse/AJ-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ