### PR TITLE
DDO-3198 Add Metadata Yaml File to  to ingest bpm into DSP backstage

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -20,6 +20,8 @@ spec:
   lifecycle: production
   owner: broadworkspaces
   system: terra
+  dependsOn:
+    - component:sam
   providesApis:
     - terra-billing-profile-manager-api
 ---

--- a/foundation.yaml
+++ b/foundation.yaml
@@ -41,7 +41,7 @@ metadata:
     github.com/project-slug: databiosphere/terra-billing-profile-manager
 spec:
   type: openapi
-  lifecycle: experimental
+  lifecycle: production
   system: terra
   owner: broadworkspaces
   definition:

--- a/foundation.yaml
+++ b/foundation.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terra-billing-profile-manager
+  description: |
+    Terra Billing Profile Manager provides an API 
+    to set up and control access to billing within 
+    Terra across cloud platforms.
+  tags:
+    - java
+    - dsp
+    - terra
+    - springboot
+    - broadworkspaces
+  annotations:
+    github.com/project-slug: databiosphere/terra-billing-profile-manager
+spec:
+  type: service
+  lifecycle: production
+  owner: broadworkspaces
+  system: terra
+  providesApis:
+    - terra-billing-profile-manager-api
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: terra-billing-profile-manager-api
+  description: |
+    Placeholder API description...
+  tags:
+    - java
+    - dsp
+    - terra
+    - springboot
+    - ${{values.owner}}
+  annotations:
+    github.com/project-slug: databiosphere/terra-billing-profile-manager
+spec:
+  type: openapi
+  lifecycle: experimental
+  system: terra
+  owner: ${{values.owner}}
+  definition:
+    $text: ./service/src/main/resources/api/service_openapi.yml
+---

--- a/foundation.yaml
+++ b/foundation.yaml
@@ -36,14 +36,14 @@ metadata:
     - dsp
     - terra
     - springboot
-    - ${{values.owner}}
+    - broadworkspaces
   annotations:
     github.com/project-slug: databiosphere/terra-billing-profile-manager
 spec:
   type: openapi
   lifecycle: experimental
   system: terra
-  owner: ${{values.owner}}
+  owner: broadworkspaces
   definition:
     $text: ./service/src/main/resources/api/service_openapi.yml
 ---


### PR DESCRIPTION
This is a functional no-op PR that just adds a metadata file to the bpm repo that is used to ingest bpm into [DSP's backstage instance](https://backstage.dsp-devops.broadinstitute.org/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=owned). Backstage is an internal platform tool that can be used for a lot of SDLC processes and improving Dev experience. DevOps is just starting to experiment with this as a means to make getting a new service stood up in the terra environments and through the prod readiness checklist easier.

But we also want all our existing services to be in the system so they can get any benefits.