### PR TITLE
DDO-3198 Fix Typo in path reference to OpenApi Spec

### DIFF
--- a/foundation.yaml
+++ b/foundation.yaml
@@ -45,5 +45,5 @@ spec:
   system: terra
   owner: broadworkspaces
   definition:
-    $text: ./service/src/main/resources/api/service_openapi.yml
+    $text: ./service/src/main/resources/api/service_openapi.yaml
 ---


### PR DESCRIPTION
Sorry for the PR spam. I had a typo in the path reference to BPM's open api spec. DevOps has some tooling that consumes these `foundation.yaml` metadata files off the `main` branch of our github repos but it makes it a bit tricky to fully vet them before they are merged.