### PR TITLE
QA-2177: Regulate the jobs that use bumper action, to prevent tag dispatch during workflows other than "Tag, publish, deploy".

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -122,7 +122,7 @@ jobs:
             "repo-owner": "${{ github.repository_owner }}",
             "repo-name": "${{ github.event.repository.name }}",
             "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}" ,
-            "release-tag": "${{ needs.bpm-app-version.outputs.tag }}"
+            "release-tag": "${{ needs.bpm-app-version.outputs.new-tag }}"
           }'
 
 ## Deactivated until WOR-890 lands
@@ -142,5 +142,5 @@ jobs:
 #          inputs: '{
 #            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
 #            "pacticipant": "bpm",
-#            "version": "${{ needs.bpm-app-version.outputs.tag }}"
+#            "version": "${{ needs.bpm-app-version.outputs.new-tag }}"
 #          }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -26,8 +26,28 @@ env:
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:
+  bump-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is-bump: ${{ steps.skiptest.outputs.is-bump }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Skip version bump merges
+        id: skiptest
+        uses: ./.github/actions/bump-skip
+        with:
+          event-name: ${{ github.event_name }}
+
+  bpm-app-version:
+    needs: [ bump-check ]
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
+    uses: ./.github/workflows/tag.yml
+    secrets:
+      BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+
   init-github-context:
     runs-on: ubuntu-latest
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     outputs:
       repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
       repo-version: ${{ steps.extract-branch.outputs.repo-version }}
@@ -60,7 +80,8 @@ jobs:
 
   bpm-consumer-contract-tests:
     runs-on: ubuntu-latest
-    needs: [init-github-context]
+    needs: [ bump-check, init-github-context ]
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     outputs:
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
 
@@ -79,15 +100,10 @@ jobs:
           NON_BREAKING_B64=$(cat service/build/pacts/bpm-sam.json | base64 -w 0)
           echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
-  bpm-app-version:
-    needs: [ init-github-context, bpm-consumer-contract-tests ]
-    uses: ./.github/workflows/tag.yml
-    secrets:
-      BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-
   publish-contracts:
     runs-on: ubuntu-latest
     needs: [ init-github-context, bpm-consumer-contract-tests, bpm-app-version ]
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     steps:
       - name: Dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -110,6 +126,7 @@ jobs:
 #  can-i-deploy:
 #    runs-on: ubuntu-latest
 #    needs: [ init-github-context, publish-contracts ]
+#    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
 #    steps:
 #      - name: Dispatch to terra-github-workflows
 #        uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -122,5 +139,5 @@ jobs:
 #          inputs: '{
 #            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
 #            "pacticipant": "bpm",
-#            "version": "${{ needs.init-github-context.outputs.repo-version }}"
+#            "version": "${{ needs.bpm-app-version.outputs.tag }}"
 #          }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           event-name: ${{ github.event_name }}
 
-  bpm-app-version:
+  regulated-tag-job:
     needs: [ bump-check ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
@@ -105,7 +105,7 @@ jobs:
 
   publish-contracts:
     runs-on: ubuntu-latest
-    needs: [ bump-check, init-github-context, bpm-consumer-contract-tests, bpm-app-version ]
+    needs: [ bump-check, init-github-context, bpm-consumer-contract-tests, regulated-tag-job ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     steps:
       - name: Dispatch to terra-github-workflows
@@ -122,7 +122,7 @@ jobs:
             "repo-owner": "${{ github.repository_owner }}",
             "repo-name": "${{ github.event.repository.name }}",
             "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}" ,
-            "release-tag": "${{ needs.bpm-app-version.outputs.new-tag }}"
+            "release-tag": "${{ needs.regulated-tag-job.outputs.new-tag }}"
           }'
 
 ## Deactivated until WOR-890 lands
@@ -142,5 +142,5 @@ jobs:
 #          inputs: '{
 #            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
 #            "pacticipant": "bpm",
-#            "version": "${{ needs.bpm-app-version.outputs.new-tag }}"
+#            "version": "${{ needs.regulated-tag-job.outputs.new-tag }}"
 #          }'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -37,6 +37,11 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
+      - name: Base branch
+        run: |
+          echo "Base branch"
+          echo "${{ github.event.before }}"
+          git describe --tags ${{ github.event.before }}
 
   bpm-app-version:
     needs: [ bump-check ]

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -44,8 +44,7 @@ jobs:
     uses: ./.github/workflows/tag.yml
     with:
       dry-run: ${{ github.event_name == 'push' }}
-    secrets:
-      BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+    secrets: inherit
 
   init-github-context:
     runs-on: ubuntu-latest

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -37,16 +37,13 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-      - name: Base branch
-        run: |
-          echo "Base branch"
-          echo "${{ github.event.before }}"
-          git describe --tags ${{ github.event.before }}
 
   bpm-app-version:
     needs: [ bump-check ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
+    with:
+      dry-run: true
     secrets:
       BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           event-name: ${{ github.event_name }}
 
+# The primary objective of this section is to carefully control the dispatching of tags,
+# ensuring it only occurs during the 'Tag, publish, deploy' workflow.
+# However, a challenge arises with contract tests, as they require knowledge of the upcoming tag
+# before the actual deployment. To address this, we leverage the dry run feature provided by bumper.
+# This allows us to obtain the next tag for publishing contracts and verifying consumer pacts without
+# triggering the tag dispatch. This approach sidesteps the need for orchestrating multiple workflows,
+# simplifying our implementation.
+#
 # We regulate the tag job to meet the following requirements according to the trigger event type:
 # 1. pull_request event (due to opening or updating of PR branch):
 #      dry-run flag is set to false

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -38,12 +38,24 @@ jobs:
         with:
           event-name: ${{ github.event_name }}
 
+# We regulate the tag job to meet the following requirements according to the trigger event type:
+# 1. pull_request event (due to opening or updating of PR branch):
+#      dry-run flag is set to false
+#         this allows the new semver tag #major.#minor.#patch-#commit to be used to identity pacticipant version for development purpose
+#         PR has no effect on the value of the latest tag in settings.gradle on disk
+# 2. PR merge to main, this triggers a push event on the main branch:
+#      dry-run flag is set to true
+#         this allows the new semver tag #major.#minor.#patch to be used to identity pacticipant version, and
+#         this action will not update the value of the latest tag in settings.gradle on disk
+#
+# Note: All workflows from the same PR merge should have the same copy of settings.gradle on disk,
+# which should be the one from the HEAD of the main branch before the workflow starts running
   regulated-tag-job:
     needs: [ bump-check ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
-      dry-run: ${{ github.event_name == 'push' }}
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     secrets: inherit
 
   init-github-context:

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -43,7 +43,7 @@ jobs:
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
-      dry-run: true
+      dry-run: ${{ github.event_name == 'push' }}
     secrets:
       BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -47,6 +47,7 @@ jobs:
 
   init-github-context:
     runs-on: ubuntu-latest
+    needs: [ bump-check ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     outputs:
       repo-branch: ${{ steps.extract-branch.outputs.repo-branch }}
@@ -102,7 +103,7 @@ jobs:
 
   publish-contracts:
     runs-on: ubuntu-latest
-    needs: [ init-github-context, bpm-consumer-contract-tests, bpm-app-version ]
+    needs: [ bump-check, init-github-context, bpm-consumer-contract-tests, bpm-app-version ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     steps:
       - name: Dispatch to terra-github-workflows
@@ -125,7 +126,7 @@ jobs:
 ## Deactivated until WOR-890 lands
 #  can-i-deploy:
 #    runs-on: ubuntu-latest
-#    needs: [ init-github-context, publish-contracts ]
+#    needs: [ bump-check, init-github-context, publish-contracts ]
 #    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
 #    steps:
 #      - name: Dispatch to terra-github-workflows

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,7 +23,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout current code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,8 +8,8 @@ on:
         default: false
         required: false
         type: string
-      print-tags:
-        description: "Echo tags to console"
+      print-tag:
+        description: "Echo tag to console"
         default: true
         required: false
         type: string
@@ -48,9 +48,10 @@ jobs:
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
           VERSION_SUFFIX: SNAPSHOT
-      - name: Echo tags to console
-        if: ${{ inputs.print-tags == 'true' }}
+      - name: Echo tag to console
+        if: ${{ inputs.print-tag == 'true' }}
         run: |
           echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"
-          echo "Value of latest tag in settings.gradle after running the action: '${{ steps.tag.outputs.tag }}'"
+          echo "settings.gradle"
+          echo "==============="
           cat settings.gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,7 @@ on:
         default: false
         required: false
         type: string
-      print-tag:
+      print-tags:
         description: "Echo tags to console"
         default: true
         required: false
@@ -48,9 +48,9 @@ jobs:
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
           VERSION_SUFFIX: SNAPSHOT
-      - name: Echo new tag to console
-        if: ${{ inputs.print-tag == 'true' }}
+      - name: Echo tags to console
+        if: ${{ inputs.print-tags == 'true' }}
         run: |
-          echo "app version tag: '${{ steps.tag.outputs.new_tag }}'"
-          echo "Value of latest tag in settings.gradle: '${{ steps.tag.outputs.tag }}'"
+          echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"
+          echo "Value of latest tag in settings.gradle after running the action: '${{ steps.tag.outputs.tag }}'"
           cat settings.gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,8 +15,11 @@ on:
         type: string
     outputs:
       tag:
-        description: "Generated tag"
+        description: "The value of the latest tag after running this action"
         value: ${{ jobs.tag-job.outputs.tag }}
+      new-tag:
+        description: "The value of the newly created tag"
+        value: ${{ jobs.tag-job.outputs.new-tag }}
     secrets:
       BROADBOT_TOKEN:
         required: true
@@ -26,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
+      new-tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout current code
         uses: actions/checkout@v3
@@ -47,4 +51,4 @@ jobs:
       - name: Echo generated tag to console
         if: ${{ inputs.print-tag == 'true' }}
         run: |
-          echo "app version tag: '${{ steps.tag.outputs.tag }}'"
+          echo "app version tag: '${{ steps.tag.outputs.new_tag }}'"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,6 +25,10 @@ on:
         required: true
 
 jobs:
+# On tag vs. new-tag.
+# The new-tag is always the tag resulting from a bump to the original tag.
+# However, the tag is by definition the value of the latest tag after running the action,
+# which might not change if dry run is used, and remains same as the original tag.
   tag-job:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       print-tag:
-        description: "Echo generated tag to console"
+        description: "Echo tags to console"
         default: true
         required: false
         type: string
@@ -48,7 +48,9 @@ jobs:
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
           VERSION_SUFFIX: SNAPSHOT
-      - name: Echo generated tag to console
+      - name: Echo new tag to console
         if: ${{ inputs.print-tag == 'true' }}
         run: |
           echo "app version tag: '${{ steps.tag.outputs.new_tag }}'"
+          echo "Value of latest tag in settings.gradle: '${{ steps.tag.outputs.tag }}'"
+          cat settings.gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,9 +3,14 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      dry-run:
+        description: "Determine the next version without tagging the branch. The workflow can use the outputs new_tag and tag in subsequent steps. Possible values are true and false (default)"
+        default: false
+        required: false
+        type: string
       print-tag:
         description: "Echo generated tag to console"
-        default: "true"
+        default: true
         required: false
         type: string
     outputs:
@@ -34,6 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           HOTFIX_BRANCHES: hotfix.*
           DEFAULT_BUMP: patch
+          DRY_RUN: ${{ inputs.dry-run }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -74,7 +74,7 @@ jobs:
     outputs:
       is-bump: ${{ steps.skiptest.outputs.is-bump }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Skip version bump merges
         id: skiptest
         uses: ./.github/actions/bump-skip
@@ -86,14 +86,14 @@ jobs:
   # is already included in the payload, making a new version tag unnecessary.
   bpm-app-version:
     needs: [ bump-check ]
-    if: ${{ inputs.pb-event-type == '' }}
+    if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     secrets:
       BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
   verify-consumer-pact:
     needs: [ bump-check, bpm-app-version ]
-    if: needs.bump-check.outputs.is-bump == 'no'
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -225,7 +225,7 @@ jobs:
 
   can-i-deploy: # The can-i-deploy job will run as a result of a PR. It reports the pact verification statuses on all deployed environments.
     runs-on: ubuntu-latest
-    if: ${{ inputs.pb-event-type == '' }} && needs.bump-check.outputs.is-bump == 'no'
+    if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
     needs: [ verify-consumer-pact, bump-check ]
     steps:
       - name: Dispatch to terra-github-workflows

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -88,7 +88,7 @@ jobs:
     if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
-      dry-run: true
+      dry-run: ${{ github.event_name == 'push' }}
     secrets:
       BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -80,11 +80,6 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-      - name: Base branch
-        run: |
-          echo "Base branch"
-          echo "${{ github.event.before }}"
-          git describe --tags ${{ github.event.before }}
   # Create a new version tag only when this workflow is triggered by a PR or merge commit.
   # If triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
   # is already included in the payload, making a new version tag unnecessary.
@@ -92,6 +87,8 @@ jobs:
     needs: [ bump-check ]
     if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
+    with:
+      dry-run: true
     secrets:
       BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -83,7 +83,7 @@ jobs:
   # Create a new version tag only when this workflow is triggered by a PR or merge commit.
   # If triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
   # is already included in the payload, making a new version tag unnecessary.
-  bpm-app-version:
+  regulated-tag-job:
     needs: [ bump-check ]
     if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
@@ -93,7 +93,7 @@ jobs:
       BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
   verify-consumer-pact:
-    needs: [ bump-check, bpm-app-version ]
+    needs: [ bump-check, regulated-tag-job ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     runs-on: ubuntu-latest
     permissions:
@@ -153,8 +153,8 @@ jobs:
 
       - name: Set provider version envvar
         run: |
-          if [[ -n "${{ needs.bpm-app-version.outputs.new-tag }}" ]]; then
-            echo "PROVIDER_VERSION=${{ needs.bpm-app-version.outputs.new-tag }}" >> $GITHUB_ENV
+          if [[ -n "${{ needs.regulated-tag-job.outputs.new-tag }}" ]]; then
+            echo "PROVIDER_VERSION=${{ needs.regulated-tag-job.outputs.new-tag }}" >> $GITHUB_ENV
           else
             echo "PROVIDER_VERSION=${{ env.PROVIDER_SHA }}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -88,7 +88,7 @@ jobs:
     if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
-      dry-run: ${{ github.event_name == 'push' }}
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -80,7 +80,11 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-
+      - name: Base branch
+        run: |
+          echo "Base branch"
+          echo "${{ github.event.before }}"
+          git describe --tags ${{ github.event.before }}
   # Create a new version tag only when this workflow is triggered by a PR or merge commit.
   # If triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
   # is already included in the payload, making a new version tag unnecessary.

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -89,8 +89,7 @@ jobs:
     uses: ./.github/workflows/tag.yml
     with:
       dry-run: ${{ github.event_name == 'push' }}
-    secrets:
-      BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+    secrets: inherit
 
   verify-consumer-pact:
     needs: [ bump-check, regulated-tag-job ]

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -80,12 +80,12 @@ jobs:
         uses: ./.github/actions/bump-skip
         with:
           event-name: ${{ github.event_name }}
-  # Create a new version tag only when this workflow is triggered by a PR or merge commit.
-  # If triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
-  # is already included in the payload, making a new version tag unnecessary.
+  # We only need a new version tag when this workflow is triggered by opening, updating a PR or PR merge.
+  # When triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
+  # is already included in the payload, then a new version tag wouldn't be needed.
   regulated-tag-job:
     needs: [ bump-check ]
-    if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
       dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Set provider version envvar
         run: |
-          if [[ -n "${{ needs.regulated-tag-job.outputs.new-tag }}" ]]; then
+          if [[ -z "${{ inputs.pb-event-type }}" ]]; then
             echo "PROVIDER_VERSION=${{ needs.regulated-tag-job.outputs.new-tag }}" >> $GITHUB_ENV
           else
             echo "PROVIDER_VERSION=${{ env.PROVIDER_SHA }}" >> $GITHUB_ENV

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -153,8 +153,8 @@ jobs:
 
       - name: Set provider version envvar
         run: |
-          if [[ -n "${{ needs.bpm-app-version.outputs.tag }}" ]]; then
-            echo "PROVIDER_VERSION=${{ needs.bpm-app-version.outputs.tag }}" >> $GITHUB_ENV
+          if [[ -n "${{ needs.bpm-app-version.outputs.new-tag }}" ]]; then
+            echo "PROVIDER_VERSION=${{ needs.bpm-app-version.outputs.new-tag }}" >> $GITHUB_ENV
           else
             echo "PROVIDER_VERSION=${{ env.PROVIDER_SHA }}" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
Ticket: [QA-2177](https://broadworkbench.atlassian.net/browse/QA-2177)

To prevent bumper action to dispatch `semver` tag more than once on PR merge.


[QA-2177]: https://broadworkbench.atlassian.net/browse/QA-2177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ