### PR TITLE
QA-2178: Add consumer version selector to provider test

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -181,9 +181,6 @@ jobs:
               git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}
             fi
           fi
-          # temporarily added this line of code for testing only
-          # remove when testing is complete and before merging
-          git checkout iv-consumer-version-selectors
           echo "git rev-parse HEAD"
           git rev-parse HEAD
 

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -181,6 +181,8 @@ jobs:
               git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}
             fi
           fi
+          # temporarily added this line of code for testing only
+          # remove when testing is complete and before merging
           git checkout iv-consumer-version-selectors
           echo "git rev-parse HEAD"
           git rev-parse HEAD

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -181,6 +181,7 @@ jobs:
               git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}
             fi
           fi
+          git checkout iv-consumer-version-selectors
           echo "git rev-parse HEAD"
           git rev-parse HEAD
 

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -83,7 +83,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 @EnableAutoConfiguration(
     exclude = {DataSourceAutoConfiguration.class, JdbcRepositoriesAutoConfiguration.class})
 public class BPMProviderTest {
-  private static final String CONSUMER_BRANCH = System.getenv("CONSUMER_BRANCH");;
+  private static final String CONSUMER_BRANCH = System.getenv("CONSUMER_BRANCH");
 
   @LocalServerPort int port;
 

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -52,8 +52,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesAutoConfiguration;
@@ -86,8 +84,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
     exclude = {DataSourceAutoConfiguration.class, JdbcRepositoriesAutoConfiguration.class})
 public class BPMProviderTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(BPMProviderTest.class);
-
   @LocalServerPort int port;
 
   @MockBean ProfileDao profileDao;
@@ -118,7 +114,7 @@ public class BPMProviderTest {
     // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
     // tag (e.g. dev, alpha).
     String consumerBranch = System.getenv("CONSUMER_BRANCH");
-    logger.debug("consumerBranch: " + consumerBranch);
+    System.out.println("consumerBranch: " + consumerBranch);
     if (StringUtils.isBlank(consumerBranch)) {
       return new SelectorBuilder().mainBranch().deployedOrReleased();
     } else {

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -83,6 +83,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 @EnableAutoConfiguration(
     exclude = {DataSourceAutoConfiguration.class, JdbcRepositoriesAutoConfiguration.class})
 public class BPMProviderTest {
+  private static final String CONSUMER_BRANCH = System.getenv("CONSUMER_BRANCH");;
 
   @LocalServerPort int port;
 
@@ -113,9 +114,7 @@ public class BPMProviderTest {
     // the changed pact.
     // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
     // tag (e.g. dev, alpha).
-    String consumerBranch = System.getenv("CONSUMER_BRANCH");
-    System.out.println("consumerBranch: " + consumerBranch);
-    if (StringUtils.isBlank(consumerBranch)) {
+    if (StringUtils.isBlank(CONSUMER_BRANCH)) {
       return new SelectorBuilder().mainBranch().deployedOrReleased();
     } else {
       return new SelectorBuilder().branch(consumerBranch);

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -117,7 +117,7 @@ public class BPMProviderTest {
     if (StringUtils.isBlank(CONSUMER_BRANCH)) {
       return new SelectorBuilder().mainBranch().deployedOrReleased();
     } else {
-      return new SelectorBuilder().branch(consumerBranch);
+      return new SelectorBuilder().branch(CONSUMER_BRANCH);
     }
   }
 


### PR DESCRIPTION
The BPM provider is missing consumer version selector, this is causing the provider to verify only the HEAD version of the consumer pact. Adding the selector enables the provider to verify the correct `CONSUMER_BRANCH` specified in the Pact Broker webhook payload. This will fix the issue @marctalbott reported about the missing verification result record in PB.