### PR TITLE
[WOR-1037] Use empty TpsPolicyInputs in pact provider state data

### DIFF
--- a/service/src/test/java/bio/terra/profile/pact/provider/ProviderStateData.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/ProviderStateData.java
@@ -1,5 +1,6 @@
 package bio.terra.profile.pact.provider;
 
+import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.profile.service.profile.model.ProfileDescription;
@@ -26,7 +27,7 @@ public class ProviderStateData {
           "");
 
   static ProfileDescription gcpBillingProfileDescription =
-      new ProfileDescription(gcpBillingProfile, Optional.empty());
+      new ProfileDescription(gcpBillingProfile, Optional.of(new TpsPolicyInputs()));
 
   static BillingProfile azureBillingProfile =
       new BillingProfile(
@@ -45,5 +46,5 @@ public class ProviderStateData {
           "");
 
   static ProfileDescription azureBillingProfileDescription =
-      new ProfileDescription(azureBillingProfile, Optional.empty());
+      new ProfileDescription(azureBillingProfile, Optional.of(new TpsPolicyInputs()));
 }


### PR DESCRIPTION
Ticket: [WOR-1037](https://broadworkbench.atlassian.net/browse/WOR-1037)
* The Rawls pact tests are still failing to verify against BPM. Hopefully this will fix it by adding an empty array for the `policies` field to the profile response rather than not including the `policies` field at all.

[WOR-1037]: https://broadworkbench.atlassian.net/browse/WOR-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ