### PR TITLE
[WOR-1037] Add empty effectiveAttributes to mocked TPS response for BPM provider tests

### DIFF
--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -15,6 +15,7 @@ import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.policy.model.TpsPaoGetResult;
+import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.profile.app.Main;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.AzureManagedAppModel;
@@ -149,7 +150,8 @@ public class BPMProviderTest {
     setUpProfileDaoGets(List.of(profile));
     when(samService.hasActions(any(), eq(SamResourceType.PROFILE), eq(profile.id())))
         .thenReturn(true);
-    when(tpsApiDispatch.getOrCreatePao(any(), any(), any())).thenReturn(new TpsPaoGetResult());
+    when(tpsApiDispatch.getOrCreatePao(any(), any(), any()))
+        .thenReturn(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()));
     return Map.of(
         "gcpProfileId", profile.id().toString(),
         "billingAccountId", profile.billingAccountId().get());
@@ -161,7 +163,8 @@ public class BPMProviderTest {
     setUpProfileDaoGets(List.of(profile));
     when(samService.hasActions(any(), eq(SamResourceType.PROFILE), eq(profile.id())))
         .thenReturn(true);
-    when(tpsApiDispatch.getOrCreatePao(any(), any(), any())).thenReturn(new TpsPaoGetResult());
+    when(tpsApiDispatch.getOrCreatePao(any(), any(), any()))
+        .thenReturn(new TpsPaoGetResult().effectiveAttributes(new TpsPolicyInputs()));
     return Map.of(
         "azureProfileId", profile.id().toString(),
         "tenantId", profile.tenantId().get().toString(),


### PR DESCRIPTION
Ticket: [WOR-1037](https://broadworkbench.atlassian.net/browse/WOR-1037)
* BPM wasn't including policies in its provider test responses because the PAO included in the mocked TPS response didn't have any attributes set. Add an empty set of attributes to the mocked PAO. I was actually able to test this one locally and saw that BPM was able to verify the Rawls consumer pact

[WOR-1037]: https://broadworkbench.atlassian.net/browse/WOR-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ