### PR TITLE
WOR-1369 [BPM] Configure dependabot to ignore some updates for client-javax module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,21 @@ updates:
     ignore:
       - dependency-name: "au.com.dius.pact*"
         update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  - package-ecosystem: "gradle"
+      directory: "/client-javax"
+      open-pull-requests-limit: 10
+      schedule:
+        interval: "weekly"
+        time: "06:00"
+        timezone: "America/New_York"
+      target-branch: "main"
+      reviewers:
+        - "@DataBiosphere/broadworkspaces"
+      labels:
+        - "dependency"
+        - "gradle"
+      commit-message:
+        prefix: "[No Ticket]"
+      ignore:
+        - dependency-name: "org.glassfish.jersey.media*"
+          update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
This pull request sets some ignore rules for dependabot to avoid updates for specific libraries. Some library updates might force us to use "jakarta" namespace instead of current "javax". This particular "client-javax" module is not supposed to use "jakarta" since this module is used by Rawls which doesn't support jakarta yet. Currently there are 2 modules which represents API client libs: 1) "client" (support jakarta) 2) client-javax (doesn't support jakarta)