### PR TITLE
Remove spotbugs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,11 +43,6 @@ jobs:
       - name: Gradle build service
         run: ./gradlew --build-cache :service:build -x test
 
-      - name: Upload spotbugs results
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: service/build/reports/spotbugs/main.sarif
-
   jib:
     needs: [ build ]
     runs-on: ubuntu-latest

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.23.0'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.4.0'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.5.0'
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.1.4'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.1.2'

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'java'
 
     id 'com.diffplug.spotless'
-    id 'com.github.spotbugs'
     id 'org.hidetake.swagger.generator'
 }
 
@@ -99,19 +98,6 @@ build {
         dependsOn(spotlessApply)
     }
     dependsOn(minniekenny)
-}
-
-// Spotbugs configuration
-spotbugs {
-    reportLevel = 'high'
-    effort = 'max'
-}
-spotbugsMain {
-    reports {
-        sarif {
-            enabled = true
-        }
-    }
 }
 
 jacocoTestReport {


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1398)
We get the needed coverage from sonarcloud and spotbugs 6.x SARIF files are incompatible with the codeql upload action. 
