### PR TITLE
[WOR-1413] Clean up our error handling during billing profile creation

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import bio.terra.profile.model.ErrorReport;
 import io.sentry.Sentry;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,16 +32,28 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
   }
 
   @Override
-  @ExceptionHandler({
-    MethodArgumentTypeMismatchException.class,
-    MissingServletRequestParameterException.class,
-    BadRequestException.class
-  })
+  @ExceptionHandler({MissingServletRequestParameterException.class, BadRequestException.class})
   public ResponseEntity<ErrorReport> validationExceptionHandler(Exception ex) {
     var errorReport =
         new ErrorReport()
             .statusCode(HttpStatus.BAD_REQUEST.value())
             .message("Invalid request: " + ex.getMessage());
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorReport);
+  }
+
+  @ExceptionHandler({
+    MethodArgumentTypeMismatchException.class,
+  })
+  public ResponseEntity<ErrorReport> mismatchedArgsHandler(MethodArgumentTypeMismatchException ex) {
+    var errorReport =
+        new ErrorReport()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .message(
+                "Invalid request: "
+                    + ex.getParameter().getParameterName()
+                    + " must be a "
+                    + Objects.requireNonNull(ex.getRequiredType()).getSimpleName().toLowerCase());
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorReport);
   }

--- a/service/src/main/java/bio/terra/profile/app/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package bio.terra.profile.app.controller;
 
 import bio.terra.common.exception.AbstractGlobalExceptionHandler;
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.common.sam.exception.SamUnauthorizedException;
 import bio.terra.profile.model.ErrorReport;
 import io.sentry.Sentry;
+import jakarta.validation.ConstraintViolationException;
 import java.util.List;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -29,14 +33,31 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
   @Override
   @ExceptionHandler({
     MethodArgumentTypeMismatchException.class,
-    MissingServletRequestParameterException.class
+    MissingServletRequestParameterException.class,
+    BadRequestException.class
   })
   public ResponseEntity<ErrorReport> validationExceptionHandler(Exception ex) {
     var errorReport =
         new ErrorReport()
             .statusCode(HttpStatus.BAD_REQUEST.value())
-            .message("Invalid request " + ex.getClass().getSimpleName());
+            .message("Invalid request: " + ex.getMessage());
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorReport);
+  }
+
+  @ExceptionHandler({DataAccessException.class})
+  public ResponseEntity<ErrorReport> constraintViolationExceptionHandler(
+      ConstraintViolationException ex) {
+    // Handle these exceptions here to avoid leaking SQL error messages to the client.
+    ErrorReport errorReport =
+        new ErrorReport().message(ex.getMessage()).statusCode(HttpStatus.BAD_REQUEST.value());
+    return new ResponseEntity<>(errorReport, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler({SamUnauthorizedException.class})
+  public ResponseEntity<ErrorReport> samUnauthorizedExceptionHandler(SamUnauthorizedException ex) {
+    ErrorReport errorReport =
+        new ErrorReport().message("Unauthorized").statusCode(HttpStatus.UNAUTHORIZED.value());
+    return new ResponseEntity<>(errorReport, HttpStatus.UNAUTHORIZED);
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/profile/exception/InvalidFieldException.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/exception/InvalidFieldException.java
@@ -1,0 +1,9 @@
+package bio.terra.profile.service.profile.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InvalidFieldException extends BadRequestException {
+  public InvalidFieldException(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
@@ -3,6 +3,7 @@ package bio.terra.profile.service.profile.model;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.model.CreateProfileRequest;
 import bio.terra.profile.model.ProfileModel;
+import bio.terra.profile.service.profile.exception.InvalidFieldException;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.Instant;
@@ -23,6 +24,8 @@ public record BillingProfile(
     Instant createdTime,
     Instant lastModified,
     String createdBy) {
+
+  private static final int MAX_BILLING_ACCT_LENGTH = 32;
 
   /**
    * Converts an {@link CreateProfileRequest} to a BillingProfile and performs validation.
@@ -49,6 +52,10 @@ public record BillingProfile(
           || request.getSubscriptionId() != null
           || request.getManagedResourceGroupId() != null) {
         throw new MissingRequiredFieldsException("GCP billing profile must not contain Azure data");
+      }
+      if (request.getBillingAccountId().length() > MAX_BILLING_ACCT_LENGTH) {
+        throw new InvalidFieldException(
+            "GCP billing account ID must be less than " + MAX_BILLING_ACCT_LENGTH + " characters");
       }
     } else if (request.getCloudPlatform().equals(CloudPlatform.AZURE)) {
       if (request.getTenantId() == null

--- a/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/model/BillingProfile.java
@@ -45,28 +45,9 @@ public record BillingProfile(
 
     // check cloud-specific fields
     if (request.getCloudPlatform().equals(CloudPlatform.GCP)) {
-      if (request.getBillingAccountId() == null) {
-        throw new MissingRequiredFieldsException("GCP billing profile requires billingAccount");
-      }
-      if (request.getTenantId() != null
-          || request.getSubscriptionId() != null
-          || request.getManagedResourceGroupId() != null) {
-        throw new MissingRequiredFieldsException("GCP billing profile must not contain Azure data");
-      }
-      if (request.getBillingAccountId().length() > MAX_BILLING_ACCT_LENGTH) {
-        throw new InvalidFieldException(
-            "GCP billing account ID must be less than " + MAX_BILLING_ACCT_LENGTH + " characters");
-      }
+      validateGcpParams(request);
     } else if (request.getCloudPlatform().equals(CloudPlatform.AZURE)) {
-      if (request.getTenantId() == null
-          || request.getSubscriptionId() == null
-          || request.getManagedResourceGroupId() == null) {
-        throw new MissingRequiredFieldsException(
-            "Azure billing profile requires tenantId, subscriptionId, managedResourceGroupId");
-      }
-      if (request.getBillingAccountId() != null) {
-        throw new MissingRequiredFieldsException("Azure billing profile must not contain GCP data");
-      }
+      validateAzureParams(request);
     }
 
     return new BillingProfile(
@@ -82,6 +63,33 @@ public record BillingProfile(
         null,
         null,
         null);
+  }
+
+  private static void validateAzureParams(CreateProfileRequest request) {
+    if (request.getTenantId() == null
+        || request.getSubscriptionId() == null
+        || request.getManagedResourceGroupId() == null) {
+      throw new MissingRequiredFieldsException(
+          "Azure billing profile requires tenantId, subscriptionId, managedResourceGroupId");
+    }
+    if (request.getBillingAccountId() != null) {
+      throw new MissingRequiredFieldsException("Azure billing profile must not contain GCP data");
+    }
+  }
+
+  private static void validateGcpParams(CreateProfileRequest request) {
+    if (request.getBillingAccountId() == null) {
+      throw new MissingRequiredFieldsException("GCP billing profile requires billingAccount");
+    }
+    if (request.getTenantId() != null
+        || request.getSubscriptionId() != null
+        || request.getManagedResourceGroupId() != null) {
+      throw new MissingRequiredFieldsException("GCP billing profile must not contain Azure data");
+    }
+    if (request.getBillingAccountId().length() > MAX_BILLING_ACCT_LENGTH) {
+      throw new InvalidFieldException(
+          "GCP billing account ID must be less than " + MAX_BILLING_ACCT_LENGTH + " characters");
+    }
   }
 
   /**

--- a/service/src/test/java/bio/terra/profile/app/controller/SpendReportingApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/SpendReportingApiControllerTest.java
@@ -72,9 +72,7 @@ class SpendReportingApiControllerTest extends BaseSpringUnitTest {
                     "spendReportEndDate", now.plusDays(30).format(DateTimeFormatter.ISO_DATE))
                 .header("Authorization", "Bearer " + userRequest.getToken()))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
-        .andExpect(
-            content()
-                .string(containsString("Invalid request MethodArgumentTypeMismatchException")));
+        .andExpect(content().string(containsString("spendReportStartDate must be a date")));
   }
 
   @Test
@@ -91,9 +89,7 @@ class SpendReportingApiControllerTest extends BaseSpringUnitTest {
                 .queryParam("spendReportEndDate", endDateWithWrongFormat)
                 .header("Authorization", "Bearer " + userRequest.getToken()))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
-        .andExpect(
-            content()
-                .string(containsString("Invalid request MethodArgumentTypeMismatchException")));
+        .andExpect(content().string(containsString("spendReportEndDate must be a date")));
   }
 
   @Test


### PR DESCRIPTION
Playing around with BPM creating GCP billing profiles, I bumped into a few issues:
* Submitting a billing account ID larger than the varchar field in the DB allows leaks the details of the `INSERT` statement in the API error 😢 . I've added a global exception handler that will catch the data source exceptions and give back a more opaque internal server error
* Related, I've added validation that the billing account ID field fits in 32 chars and if not gives back an `InvalidFieldException` 
* Using a bad access token will no longer give back the slightly wonky `Error getting user email from Sam:`; instead it will return a plain "Unauthorized" message.
* Breaks out a separate handler for the mismatched arg type handling to give back more meaningful error messages (i.e., when the date for spend reporting cannot be parsed we were previously giving back a blunt error msg and the exception type, now it will output the bad parameter's name and the expected parameter type).