### PR TITLE
[WOR-1439] Micrometer: publish percentile histograms for per-endpoint latencies

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -63,6 +63,12 @@ management:
     web:
       exposure:
         include: "*"
+  metrics:
+    distribution:
+      # Used to publish a histogram suitable for computing aggregable (across dimensions) percentile
+      # latency approximations in Prometheus (by using histogram_quantile)
+      # For more information: https://micrometer.io/docs/concepts#_histograms_and_percentiles
+      percentiles-histogram[http.server.requests]: true
 
 profile:
   ingress:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1439

BPM was already publishing Micrometer metrics to Prometheus for exposure in Grafana.  This PR adds additional configuration to collect percentile histogram metrics, which will enable us to visualize per-endpoint percentile latencies across different dimensions (e.g. broken up by status).

**Manual Verification**

These metrics only show up for an endpoint when a request is made.  I ran a local BPM, navigated to Swagger, and hit the `/status` endpoint several times.

I then navigated to `http://localhost:9098/actuator/prometheus` and verified that metrics were being collected for my interactions:
```
_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.003495251",} 1.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.003844776",} 2.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.004194304",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.005592405",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.006990506",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.008388607",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.009786708",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.011184809",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.01258291",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.013981011",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.015379112",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.016777216",} 3.0
http_server_requests_seconds_bucket{error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/status",le="0.022369621",} 4.0
```

**Follow-On Work**
Once merged, update the workspace Grafana [dashboard](https://grafana.dsp-devops.broadinstitute.org/d/38IazciVz/workspaces?orgId=1) to display P50 and P95 latencies (anywhere that we're currently displaying an average latency is a good candidate).