### PR TITLE
WOR-1373 Billing Project user feedback: Update cost groupings in ToA Billing Project spend report.

### DIFF
--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingService.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingService.java
@@ -109,7 +109,7 @@ public class AzureSpendReportingService {
             subscriptionId, resourceGroupName, from, to);
     if (isAksResourceGroup) {
       return queryResultMapper.mapQueryResult(
-          costQueryResponse.getValue(), SpendCategoryType.COMPUTE, from, to);
+          costQueryResponse.getValue(), SpendCategoryType.WORKSPACE_INFRASTRUCTURE, from, to);
     } else {
       return queryResultMapper.mapQueryResult(costQueryResponse.getValue(), from, to);
     }

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/exception/UnexpectedCostManagementDataFormat.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/exception/UnexpectedCostManagementDataFormat.java
@@ -1,0 +1,9 @@
+package bio.terra.profile.service.spendreporting.azure.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class UnexpectedCostManagementDataFormat extends InternalServerErrorException {
+  public UnexpectedCostManagementDataFormat(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/AzureResourceProviderType.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/AzureResourceProviderType.java
@@ -1,0 +1,28 @@
+package bio.terra.profile.service.spendreporting.azure.model;
+
+import org.apache.commons.lang3.StringUtils;
+
+public enum AzureResourceProviderType {
+  COMPUTE("microsoft.compute"),
+  BATCH("microsoft.batch"),
+  STORAGE("microsoft.storage");
+
+  private String value;
+
+  AzureResourceProviderType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static AzureResourceProviderType fromString(String value) {
+    for (AzureResourceProviderType type : AzureResourceProviderType.values()) {
+      if (StringUtils.equalsIgnoreCase(type.getValue(), value)) {
+        return type;
+      }
+    }
+    return null;
+  }
+}

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/AzureResourceProviderType.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/AzureResourceProviderType.java
@@ -1,5 +1,6 @@
 package bio.terra.profile.service.spendreporting.azure.model;
 
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public enum AzureResourceProviderType {
@@ -17,12 +18,12 @@ public enum AzureResourceProviderType {
     return value;
   }
 
-  public static AzureResourceProviderType fromString(String value) {
+  public static Optional<AzureResourceProviderType> fromString(String value) {
     for (AzureResourceProviderType type : AzureResourceProviderType.values()) {
       if (StringUtils.equalsIgnoreCase(type.getValue(), value)) {
-        return type;
+        return Optional.of(type);
       }
     }
-    return null;
+    return Optional.empty();
   }
 }

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/SpendCategoryType.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/SpendCategoryType.java
@@ -1,6 +1,7 @@
 package bio.terra.profile.service.spendreporting.azure.model;
 
 public enum SpendCategoryType {
+  WORKSPACE_INFRASTRUCTURE,
   COMPUTE,
   STORAGE,
   OTHER

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapper.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapper.java
@@ -13,11 +13,12 @@ public class SpendDataItemCategoryMapper {
       Set.of(AzureResourceProviderType.STORAGE);
 
   public SpendCategoryType mapResourceCategory(String resourceCategory) {
-    if (AZURE_COMPUTE_RESOURCE_TYPES.contains(
-        AzureResourceProviderType.fromString(resourceCategory))) {
+    var type = AzureResourceProviderType.fromString(resourceCategory);
+    if (type.isEmpty()) return SpendCategoryType.OTHER;
+
+    if (AZURE_COMPUTE_RESOURCE_TYPES.contains(type.get())) {
       return SpendCategoryType.COMPUTE;
-    } else if (AZURE_STORAGE_RESOURCE_TYPES.contains(
-        AzureResourceProviderType.fromString(resourceCategory))) {
+    } else if (AZURE_STORAGE_RESOURCE_TYPES.contains(type.get())) {
       return SpendCategoryType.STORAGE;
     } else {
       return SpendCategoryType.OTHER;

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapper.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapper.java
@@ -1,22 +1,23 @@
 package bio.terra.profile.service.spendreporting.azure.model.mapper;
 
+import bio.terra.profile.service.spendreporting.azure.model.AzureResourceProviderType;
 import bio.terra.profile.service.spendreporting.azure.model.SpendCategoryType;
-import java.util.Locale;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SpendDataItemCategoryMapper {
-  public static final String AZURE_COMPUTE_RESOURCE_TYPE = "microsoft.compute";
-  public static final String AZURE_STORAGE_RESOURCE_TYPE = "microsoft.storage";
+  public static final Set<AzureResourceProviderType> AZURE_COMPUTE_RESOURCE_TYPES =
+      Set.of(AzureResourceProviderType.COMPUTE, AzureResourceProviderType.BATCH);
+  public static final Set<AzureResourceProviderType> AZURE_STORAGE_RESOURCE_TYPES =
+      Set.of(AzureResourceProviderType.STORAGE);
 
   public SpendCategoryType mapResourceCategory(String resourceCategory) {
-    if (resourceCategory
-        .toLowerCase(Locale.ROOT)
-        .startsWith(AZURE_COMPUTE_RESOURCE_TYPE.toLowerCase(Locale.ROOT))) {
+    if (AZURE_COMPUTE_RESOURCE_TYPES.contains(
+        AzureResourceProviderType.fromString(resourceCategory))) {
       return SpendCategoryType.COMPUTE;
-    } else if (resourceCategory
-        .toLowerCase(Locale.ROOT)
-        .startsWith(AZURE_STORAGE_RESOURCE_TYPE.toLowerCase(Locale.ROOT))) {
+    } else if (AZURE_STORAGE_RESOURCE_TYPES.contains(
+        AzureResourceProviderType.fromString(resourceCategory))) {
       return SpendCategoryType.STORAGE;
     } else {
       return SpendCategoryType.OTHER;

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapper.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapper.java
@@ -12,8 +12,8 @@ public class SpendDataItemCategoryMapper {
   public static final Set<AzureResourceProviderType> AZURE_STORAGE_RESOURCE_TYPES =
       Set.of(AzureResourceProviderType.STORAGE);
 
-  public SpendCategoryType mapResourceCategory(String resourceCategory) {
-    var type = AzureResourceProviderType.fromString(resourceCategory);
+  public SpendCategoryType mapResourceCategory(String resourceProviderType) {
+    var type = AzureResourceProviderType.fromString(resourceProviderType);
     if (type.isEmpty()) return SpendCategoryType.OTHER;
 
     if (AZURE_COMPUTE_RESOURCE_TYPES.contains(type.get())) {

--- a/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataMapper.java
+++ b/service/src/main/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataMapper.java
@@ -83,6 +83,9 @@ public class SpendDataMapper {
   private static SpendReportingForDateRange.CategoryEnum mapCategory(
       SpendCategoryType spendCategoryType) {
     switch (spendCategoryType) {
+      case WORKSPACE_INFRASTRUCTURE -> {
+        return SpendReportingForDateRange.CategoryEnum.WORKSPACEINFRASTRUCTURE;
+      }
       case STORAGE -> {
         return SpendReportingForDateRange.CategoryEnum.STORAGE;
       }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -742,6 +742,7 @@ components:
         category:
           type: string
           enum:
+            - WorkspaceInfrastructure
             - Storage
             - Compute
             - Other

--- a/service/src/test/java/bio/terra/profile/common/SpendDataFixtures.java
+++ b/service/src/test/java/bio/terra/profile/common/SpendDataFixtures.java
@@ -1,9 +1,9 @@
 package bio.terra.profile.common;
 
+import bio.terra.profile.service.spendreporting.azure.model.AzureResourceProviderType;
 import bio.terra.profile.service.spendreporting.azure.model.SpendCategoryType;
 import bio.terra.profile.service.spendreporting.azure.model.SpendData;
 import bio.terra.profile.service.spendreporting.azure.model.SpendDataItem;
-import bio.terra.profile.service.spendreporting.azure.model.mapper.SpendDataItemCategoryMapper;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -22,19 +22,19 @@ public class SpendDataFixtures {
   public static SpendData buildDefaultSpendData() {
     var computeSpendDataItem =
         buildSpendDataItem(
-            SpendDataItemCategoryMapper.AZURE_COMPUTE_RESOURCE_TYPE,
+            AzureResourceProviderType.COMPUTE.getValue(),
             DEFAULT_COMPUTE1_COST,
             DEFAULT_CURRENCY,
             SpendCategoryType.COMPUTE);
     var computeSpendDataItem2 =
         buildSpendDataItem(
-            SpendDataItemCategoryMapper.AZURE_COMPUTE_RESOURCE_TYPE,
+            AzureResourceProviderType.COMPUTE.getValue(),
             DEFAULT_COMPUTE2_COST,
             DEFAULT_CURRENCY,
             SpendCategoryType.COMPUTE);
     var storageSpendDataItem =
         buildSpendDataItem(
-            SpendDataItemCategoryMapper.AZURE_COMPUTE_RESOURCE_TYPE,
+            AzureResourceProviderType.STORAGE.getValue(),
             DEFAULT_STORAGE_COST,
             DEFAULT_CURRENCY,
             SpendCategoryType.STORAGE);

--- a/service/src/test/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingServiceUnitTest.java
@@ -140,7 +140,8 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
             SpendCategoryType.STORAGE,
             from,
             to);
-    when(mockQueryResultMapper.mapQueryResult(queryResult2, SpendCategoryType.COMPUTE, from, to))
+    when(mockQueryResultMapper.mapQueryResult(
+            queryResult2, SpendCategoryType.WORKSPACE_INFRASTRUCTURE, from, to))
         .thenReturn(spendData2);
 
     var spendData = azureSpendReportingService.getBillingProfileSpendData(billingProfile, from, to);

--- a/service/src/test/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingServiceUnitTest.java
@@ -58,17 +58,21 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
   private static final String K8S_RESOURCE_NAME = "k8sResource";
   private static final String K8S_RESOURCE_NAME2 = "k8sResource2";
 
-  private static final String COMPUTE_RESOURCE_TYPE = "microsoft.compute";
-  private static final String STORAGE_RESOURCE_TYPE = "microsoft.storage";
+  private static final String COMPUTE_RESOURCE_PROVIDER_TYPE = "microsoft.compute";
+  private static final String STORAGE_RESOURCE_PROVIDER_TYPE = "microsoft.storage";
+  // one of the possible resource under K8s node resource group
+  private static final String NETWORK_RESOURCE_PROVIDER_TYPE = "microsoft.network";
 
   private static final String K8S_NODE_RESOURCE_GROUP_NAME = "mrgName_aks";
 
   private static final Map<String, List<Object>> QUERY_RESULT_DATA =
       Map.of(
-          COMPUTE_RESOURCE_TYPE,
-          List.of("10.55", COMPUTE_RESOURCE_TYPE, "USD"),
-          STORAGE_RESOURCE_TYPE,
-          List.of("20.99", STORAGE_RESOURCE_TYPE, "USD"));
+          COMPUTE_RESOURCE_PROVIDER_TYPE,
+          List.of("10.55", COMPUTE_RESOURCE_PROVIDER_TYPE, "USD"),
+          STORAGE_RESOURCE_PROVIDER_TYPE,
+          List.of("20.99", STORAGE_RESOURCE_PROVIDER_TYPE, "USD"),
+          NETWORK_RESOURCE_PROVIDER_TYPE,
+          List.of("21.99", STORAGE_RESOURCE_PROVIDER_TYPE, "USD"));
 
   private AzureSpendReportingService azureSpendReportingService;
 
@@ -108,7 +112,8 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
         true);
     Response<QueryResult> response1 = mock(Response.class);
     QueryResult queryResult1 = mock(QueryResult.class);
-    when(queryResult1.rows()).thenReturn(List.of(QUERY_RESULT_DATA.get(COMPUTE_RESOURCE_TYPE)));
+    when(queryResult1.rows())
+        .thenReturn(List.of(QUERY_RESULT_DATA.get(COMPUTE_RESOURCE_PROVIDER_TYPE)));
     when(response1.getValue()).thenReturn(queryResult1);
     when(mockAzureCostManagementQuery.resourceGroupCostQueryWithResourceTypeGrouping(
             SUBSCRIPTION_ID, RESOURCE_GROUP_NAME, from, to))
@@ -116,7 +121,8 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
 
     Response<QueryResult> response2 = mock(Response.class);
     QueryResult queryResult2 = mock(QueryResult.class);
-    when(queryResult2.rows()).thenReturn(List.of(QUERY_RESULT_DATA.get(STORAGE_RESOURCE_TYPE)));
+    when(queryResult2.rows())
+        .thenReturn(List.of(QUERY_RESULT_DATA.get(NETWORK_RESOURCE_PROVIDER_TYPE)));
     when(response2.getValue()).thenReturn(queryResult2);
     when(mockAzureCostManagementQuery.resourceGroupCostQueryWithResourceTypeGrouping(
             SUBSCRIPTION_ID, K8S_NODE_RESOURCE_GROUP_NAME, from, to))
@@ -124,7 +130,7 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
 
     var spendData1 =
         SpendDataFixtures.buildSingleItemSpendData(
-            COMPUTE_RESOURCE_TYPE,
+            COMPUTE_RESOURCE_PROVIDER_TYPE,
             new BigDecimal("10.55"),
             "USD",
             SpendCategoryType.COMPUTE,
@@ -134,10 +140,10 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
 
     var spendData2 =
         SpendDataFixtures.buildSingleItemSpendData(
-            STORAGE_RESOURCE_TYPE,
-            new BigDecimal("20.99"),
+            NETWORK_RESOURCE_PROVIDER_TYPE,
+            new BigDecimal("21.99"),
             "USD",
-            SpendCategoryType.STORAGE,
+            SpendCategoryType.WORKSPACE_INFRASTRUCTURE,
             from,
             to);
     when(mockQueryResultMapper.mapQueryResult(
@@ -180,7 +186,7 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
     assertTrue(computeItem.isPresent());
     var storageItem =
         spendData.getSpendDataItems().stream()
-            .filter(i -> i.spendCategoryType().equals(SpendCategoryType.STORAGE))
+            .filter(i -> i.spendCategoryType().equals(SpendCategoryType.WORKSPACE_INFRASTRUCTURE))
             .findFirst();
     assertTrue(storageItem.isPresent());
     assertThat(spendData.getFrom(), equalTo(from));

--- a/service/src/test/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/spendreporting/azure/AzureSpendReportingServiceUnitTest.java
@@ -184,11 +184,11 @@ class AzureSpendReportingServiceUnitTest extends BaseUnitTest {
             .filter(i -> i.spendCategoryType().equals(SpendCategoryType.COMPUTE))
             .findFirst();
     assertTrue(computeItem.isPresent());
-    var storageItem =
+    var networkItem =
         spendData.getSpendDataItems().stream()
             .filter(i -> i.spendCategoryType().equals(SpendCategoryType.WORKSPACE_INFRASTRUCTURE))
             .findFirst();
-    assertTrue(storageItem.isPresent());
+    assertTrue(networkItem.isPresent());
     assertThat(spendData.getFrom(), equalTo(from));
     assertThat(spendData.getTo(), equalTo(to));
   }

--- a/service/src/test/java/bio/terra/profile/service/spendreporting/azure/model/mapper/QueryResultMapperUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/spendreporting/azure/model/mapper/QueryResultMapperUnitTest.java
@@ -86,7 +86,8 @@ class QueryResultMapperUnitTest extends BaseUnitTest {
   @Test
   void testMapValidQueryResultSuccess() {
     List<List<Object>> rows = new ArrayList<>();
-    List<Object> row = List.of(15.23, AzureResourceProviderType.COMPUTE.getValue(), "USD");
+    List<Object> row =
+        List.of(15.23, AzureResourceProviderType.COMPUTE.getValue() + "/virtualMachines", "USD");
     rows.add(row);
 
     var queryResult = mockValidQueryResult(rows);

--- a/service/src/test/java/bio/terra/profile/service/spendreporting/azure/model/mapper/QueryResultMapperUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/spendreporting/azure/model/mapper/QueryResultMapperUnitTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.service.spendreporting.azure.exception.UnexpectedCostManagementQueryResponse;
+import bio.terra.profile.service.spendreporting.azure.model.AzureResourceProviderType;
 import bio.terra.profile.service.spendreporting.azure.model.SpendCategoryType;
 import bio.terra.profile.service.spendreporting.azure.model.SpendData;
 import com.azure.resourcemanager.costmanagement.models.QueryColumn;
@@ -85,8 +86,7 @@ class QueryResultMapperUnitTest extends BaseUnitTest {
   @Test
   void testMapValidQueryResultSuccess() {
     List<List<Object>> rows = new ArrayList<>();
-    List<Object> row =
-        List.of(15.23, SpendDataItemCategoryMapper.AZURE_COMPUTE_RESOURCE_TYPE, "USD");
+    List<Object> row = List.of(15.23, AzureResourceProviderType.COMPUTE.getValue(), "USD");
     rows.add(row);
 
     var queryResult = mockValidQueryResult(rows);

--- a/service/src/test/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapperUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/spendreporting/azure/model/mapper/SpendDataItemCategoryMapperUnitTest.java
@@ -1,11 +1,10 @@
 package bio.terra.profile.service.spendreporting.azure.model.mapper;
 
-import static bio.terra.profile.service.spendreporting.azure.model.mapper.SpendDataItemCategoryMapper.AZURE_COMPUTE_RESOURCE_TYPE;
-import static bio.terra.profile.service.spendreporting.azure.model.mapper.SpendDataItemCategoryMapper.AZURE_STORAGE_RESOURCE_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.profile.common.BaseUnitTest;
+import bio.terra.profile.service.spendreporting.azure.model.AzureResourceProviderType;
 import bio.terra.profile.service.spendreporting.azure.model.SpendCategoryType;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,14 +24,23 @@ class SpendDataItemCategoryMapperUnitTest extends BaseUnitTest {
   @Test
   void testCompute() {
     assertThat(
-        spendDataItemCategoryMapper.mapResourceCategory(AZURE_COMPUTE_RESOURCE_TYPE),
+        spendDataItemCategoryMapper.mapResourceCategory(
+            AzureResourceProviderType.COMPUTE.getValue()),
+        equalTo(SpendCategoryType.COMPUTE));
+  }
+
+  @Test
+  void testBatch() {
+    assertThat(
+        spendDataItemCategoryMapper.mapResourceCategory(AzureResourceProviderType.BATCH.getValue()),
         equalTo(SpendCategoryType.COMPUTE));
   }
 
   @Test
   void testStorage() {
     assertThat(
-        spendDataItemCategoryMapper.mapResourceCategory(AZURE_STORAGE_RESOURCE_TYPE),
+        spendDataItemCategoryMapper.mapResourceCategory(
+            AzureResourceProviderType.STORAGE.getValue()),
         equalTo(SpendCategoryType.STORAGE));
   }
 


### PR DESCRIPTION
This change introduce:

1. new spend report category - "WorkspaceInfrastructure'. This category includes all resources under K8s node resource group. Everything else will go to "Compute/Storate/Other" categories:
2. adjustment to Compute category. This will include all resources with the following resource providers type "microsoft.compute", "microsoft.batch" which reside in MRG
3. adjustment to Storage category. This will include all resources with the following resource providers type "microsoft.storage" which reside in MRG
4. Everything else will go to Other category.