### PR TITLE
[WOR-1520] Upgrade Sam client, remove json constraint

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     // These are not directly included, they are just constrained if they are pulled in as
     // transitive dependencies.
     constraints {
-        implementation('org.json:json:20231013')
         implementation('org.graalvm.sdk:graal-sdk:23.1.2')
     }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -42,14 +42,7 @@ dependencies {
 	implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.7-SNAPSHOT"
 
 	// Sam
-	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-fd8ee25"
-
-	// Transitive dependency constraints due to security vulnerabilities in prior versions.
-	// These are not directly included, they are just constrained if they are pulled in as
-	// transitive dependencies.
-	constraints {
-		implementation('org.json:json:20231013')
-	}
+	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "0.1-0c4b377"
 
     // TPS
     implementation group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT"

--- a/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/SamServiceTest.java
@@ -22,6 +22,7 @@ public class SamServiceTest {
 
   @Pact(consumer = "bpm", provider = "sam")
   public RequestResponsePact statusApiPact(PactDslWithProvider builder) {
+    var statusShape = new PactDslJsonBody().booleanValue("ok", true).object("systems");
     return builder
         .given("Sam is ok")
         .uponReceiving("a status request")
@@ -29,7 +30,7 @@ public class SamServiceTest {
         .method("GET")
         .willRespondWith()
         .status(200)
-        .body(new PactDslJsonBody().booleanValue("ok", true))
+        .body(statusShape)
         .toPact();
   }
 
@@ -39,7 +40,8 @@ public class SamServiceTest {
         new PactDslJsonBody()
             .stringType("userSubjectId")
             .stringType("userEmail")
-            .booleanType("enabled");
+            .booleanType("enabled")
+            .booleanType("adminEnabled");
     return builder
         .given("user status info request with access token")
         .uponReceiving("a request for the user's status")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1520

We previously constrained `org.json:json` to move past a vulnerable version when pulled in as a transitive dependency.  The only place where this happened was within the Sam client.

Now that the Sam client no longer presents this vulnerability, we can remove the constraint along with updating Sam client.

This simplifies dependency management: one less dependency for Dependabot to chase.  On merging this PR, https://github.com/DataBiosphere/terra-billing-profile-manager/pull/403 should close automatically (I'll circle back to it to make sure).

Verified:
```
(base) okotsopo@wm111-e35 terra-billing-profile-manager % ./gradlew :service:dependencyInsight --dependency org.json:json
…
> Task :service:dependencyInsight
org.json:json:20240205
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |
   Selection reasons:
      - By conflict resolution: between versions 20240205 and 20140107

org.json:json:20240205
\--- org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-0c4b377
     \--- compileClasspath

org.json:json:20140107 -> 20240205
\--- org.apache.oltu.oauth2:org.apache.oltu.oauth2.common:1.0.2
     \--- org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2
          \--- org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-0c4b377
               \--- compileClasspath
```
What dependencyInsight tells us above is that our build uses `org.json:json:20240205`, a non-vulnerable version.  It is a direct dependency of the Sam client, which is resolving its own conflict with an earlier version.