### PR TITLE
[WOR-1563] Support running on AKS

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -88,6 +88,7 @@ profile:
   policy:
     client-credential-file-path: build/resources/main/generated/bpm-client-sa.json
     base-path: ${env.tps.basePath}
+    azure-control-plane-enabled: false
 
   stairway-database:
     password: ${env.db.stairway.pass}


### PR DESCRIPTION
Support getting auth token from azure workload identity instead of gcp service account to auth with TPS. Equivalent to this PR in WSM https://github.com/DataBiosphere/terra-workspace-manager/pull/1548