### PR TITLE
[WOR-1533] Spring Boot dependency: pin postgresql to 42.7.2

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
@@ -5,3 +5,6 @@ plugins {
     id 'io.spring.dependency-management'
     id 'org.springframework.boot'
 }
+
+// Spring Boot 3.1.2 pulls in postgresql 42.6.0, vulnerable to CVE-2024-1597
+ext['postgresql.version'] = '42.7.2'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1533

Our current version of Spring Boot is [3.1.2](https://github.com/DataBiosphere/terra-billing-profile-manager/blob/d2501ad8d2d6065c78236245bf74fa7fdebd244d/buildSrc/build.gradle#L18), which [brings in postgresql 42.6.0](https://github.com/spring-projects/spring-boot/blob/v3.1.2/spring-boot-project/spring-boot-dependencies/build.gradle#L1096-L1102).

To mitigate a security vulnerability, we must instruct Spring Boot use a non-vulnerable version.

I first tried upgrading our TCL to see if that would fix things but this had no impact: the Spring Boot pin was both necessary and sufficient, so I will pursue the TCL upgrade separately as it's a larger change.