### PR TITLE
grantaar TOAZ 343 - support ServiceCatalog deployed managed apps

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
@@ -18,9 +18,18 @@ public class PolicyServiceConfiguration {
 
   private String basePath;
   private String clientCredentialFilePath;
+  private Boolean azureControlPlaneEnabled;
 
   private static final List<String> POLICY_SERVICE_ACCOUNT_SCOPES =
       List.of("openid", "email", "profile");
+
+  public void setAzureControlPlaneEnabled(Boolean azureControlPlaneEnabled) {
+    this.azureControlPlaneEnabled = azureControlPlaneEnabled;
+  }
+
+  public Boolean getAzureControlPlaneEnabled() {
+    return azureControlPlaneEnabled;
+  }
 
   public String getBasePath() {
     return basePath;

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -2,6 +2,7 @@ package bio.terra.profile.service.azure;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
+import bio.terra.profile.app.configuration.PolicyServiceConfiguration;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.service.azure.exception.InaccessibleSubscriptionException;
@@ -30,6 +31,7 @@ public class AzureService {
   public static final String AZURE_SUB_NOT_FOUND = "SubscriptionNotFound";
   public static final String AZURE_AUTH_FAILED = "AuthorizationFailed";
   public static final String INVALID_AUTH_TOKEN = "InvalidAuthenticationTokenTenant";
+  public static final String AUTHORIZED_USER_KEY = "authorizedTerraUser";
 
   private static final Set<String> INACCESSIBLE_SUB_CODES =
       Set.of(AZURE_SUB_NOT_FOUND, AZURE_AUTH_FAILED, INVALID_AUTH_TOKEN);
@@ -37,13 +39,18 @@ public class AzureService {
   private final AzureCrlService crlService;
   private final Set<AzureConfiguration.AzureApplicationOffer> azureAppOffers;
   private final ProfileDao profileDao;
+  private final PolicyServiceConfiguration policyServiceConfiguration;
 
   @Autowired
   public AzureService(
-      AzureCrlService crlService, AzureConfiguration azureConfiguration, ProfileDao profileDao) {
+      AzureCrlService crlService,
+      AzureConfiguration azureConfiguration,
+      ProfileDao profileDao,
+      PolicyServiceConfiguration policyServiceConfiguration) {
     this.crlService = crlService;
     this.azureAppOffers = azureConfiguration.getApplicationOffers();
     this.profileDao = profileDao;
+    this.policyServiceConfiguration = policyServiceConfiguration;
   }
 
   /**
@@ -60,7 +67,6 @@ public class AzureService {
     var tenantId = getTenantForSubscription(subscriptionId);
 
     Stream<Application> applications = getApplicationsForSubscription(subscriptionId);
-
     List<String> assignedManagedResourceGroups =
         profileDao.listManagedResourceGroupsInSubscription(subscriptionId);
 
@@ -110,43 +116,57 @@ public class AzureService {
   }
 
   private boolean isAuthedTerraManagedApp(AuthenticatedUserRequest userRequest, Application app) {
-    if (app.plan() == null) {
-      logger.debug(
-          "App deployment has no plan, ignoring [mrg_id={}]", app.managedResourceGroupId());
-      return false;
-    }
+    if (!policyServiceConfiguration.getAzureControlPlaneEnabled()) {
+      // not running under Azure Control Plane, match plan product name, publisher, and authed user email
+      if (app.plan() == null) {
+        logger.debug(
+            "App deployment has no plan, ignoring [mrg_id={}]", app.managedResourceGroupId());
+        return false;
+      }
 
-    var maybeOffer =
-        azureAppOffers.stream()
-            .filter(
-                o ->
-                    o.getName().equals(app.plan().product())
-                        && o.getPublisher().equals(app.plan().publisher()))
-            .findFirst();
-    if (maybeOffer.isEmpty()) {
-      logger.debug(
-          "App deployment is not a deployment of a well-known Terra offer, ignoring [mrg_id={}]",
-          app.managedResourceGroupId());
-      return false;
-    }
-
-    var offer = maybeOffer.get();
-    var authedUserKey = offer.getAuthorizedUserKey();
-    if (app.parameters() != null && app.parameters() instanceof Map rawParams) {
-      if (!rawParams.containsKey(authedUserKey)) {
-        logger.warn(
-            "Terra app deployment with no authorized user key {} [mrg_id={}]",
-            authedUserKey,
+      var maybeOffer =
+          azureAppOffers.stream()
+              .filter(
+                  o ->
+                      o.getName().equals(app.plan().product())
+                          && o.getPublisher().equals(app.plan().publisher()))
+              .findFirst();
+      if (maybeOffer.isEmpty()) {
+        logger.debug(
+            "App deployment is not a deployment of a well-known Terra offer, ignoring [mrg_id={}]",
             app.managedResourceGroupId());
         return false;
       }
-      var paramValues = (Map) rawParams.get(authedUserKey);
-      var authedUsers = ((String) paramValues.get("value")).split(",");
 
-      return Arrays.stream(authedUsers)
-          .anyMatch(user -> user.trim().equalsIgnoreCase(userRequest.getEmail()));
+      var offer = maybeOffer.get();
+      var authedUserKey = offer.getAuthorizedUserKey();
+      if (app.parameters() != null && app.parameters() instanceof Map rawParams) {
+        if (!rawParams.containsKey(authedUserKey)) {
+          logger.warn(
+              "Terra app deployment with no authorized user key {} [mrg_id={}]",
+              authedUserKey,
+              app.managedResourceGroupId());
+          return false;
+        }
+        var paramValues = (Map) rawParams.get(authedUserKey);
+        var authedUsers = ((String) paramValues.get("value")).split(",");
+
+        return Arrays.stream(authedUsers)
+            .anyMatch(user -> user.trim().equalsIgnoreCase(userRequest.getEmail()));
+      }
+
+      return false;
+    } else {
+      // running under Azure Control Plane, match ServiceCatalog kind and authed user email
+      if (app.kind().equals("ServiceCatalog")) {
+        if (app.parameters() != null && app.parameters() instanceof Map rawParams) {
+          var paramValues = (Map) rawParams.get(AUTHORIZED_USER_KEY);
+          var authedUsers = ((String) paramValues.get("value")).split(",");
+          return Arrays.stream(authedUsers)
+              .anyMatch(user -> user.trim().equalsIgnoreCase(userRequest.getEmail()));
+        }
+      }
     }
-
     return false;
   }
 
@@ -165,6 +185,7 @@ public class AzureService {
       SubscriptionClient sc = resourceManager.subscriptionClient();
       var subscription = sc.getSubscriptions().get(subscriptionId.toString());
       return UUID.fromString(subscription.tenantId());
+      // return UUID.fromString("72f988bf-86f1-41af-91ab-2d7cd011db47");
     } catch (ManagementException e) {
       if (INACCESSIBLE_SUB_CODES.contains(e.getValue().getCode())) {
         throw new InaccessibleSubscriptionException("Subscription not accessible", e);

--- a/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
+++ b/service/src/main/java/bio/terra/profile/service/azure/AzureService.java
@@ -185,7 +185,6 @@ public class AzureService {
       SubscriptionClient sc = resourceManager.subscriptionClient();
       var subscription = sc.getSubscriptions().get(subscriptionId.toString());
       return UUID.fromString(subscription.tenantId());
-      // return UUID.fromString("72f988bf-86f1-41af-91ab-2d7cd011db47");
     } catch (ManagementException e) {
       if (INACCESSIBLE_SUB_CODES.contains(e.getValue().getCode())) {
         throw new InaccessibleSubscriptionException("Subscription not accessible", e);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -88,6 +88,7 @@ profile:
   policy:
     client-credential-file-path: build/resources/main/generated/bpm-client-sa.json
     base-path: ${env.tps.basePath}
+    azure-control-plane-enabled: false
 
   stairway-database:
     password: ${env.db.stairway.pass}
@@ -113,7 +114,8 @@ profile:
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
 
     application-offers:
-      - name: terra-dev-preview
+      #- name: terra-dev-preview
+      - name: terra-prod #temp change to support finding prod apps deployed to internal msft subscription
         publisher: thebroadinstituteinc1615909626976
         authorized-user-key: authorizedTerraUser
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -114,8 +114,7 @@ profile:
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
 
     application-offers:
-      #- name: terra-dev-preview
-      - name: terra-prod #temp change to support finding prod apps deployed to internal msft subscription
+      - name: terra-prod
         publisher: thebroadinstituteinc1615909626976
         authorized-user-key: authorizedTerraUser
 


### PR DESCRIPTION
- use the existing policy feature flag:    azure-control-plane-enabled: true/false
- when feature flag is true, the api/azure/v1/managedApps endpoint returns managed apps deployed from an Azure ServiceCatalog instead of the Marketplace
