### PR TITLE
grantaar-TOAZ-343

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
@@ -26,6 +26,14 @@ public class PolicyServiceConfiguration {
   private static final List<String> POLICY_SERVICE_ACCOUNT_SCOPES =
       List.of("openid", "email", "profile");
 
+  public void setAzureControlPlaneEnabled(Boolean azureControlPlaneEnabled) {
+    this.azureControlPlaneEnabled = azureControlPlaneEnabled;
+  }
+
+  public Boolean getAzureControlPlaneEnabled() {
+    return azureControlPlaneEnabled;
+  }
+
   public String getBasePath() {
     return basePath;
   }

--- a/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
@@ -26,15 +26,7 @@ public class PolicyServiceConfiguration {
   private static final List<String> POLICY_SERVICE_ACCOUNT_SCOPES =
       List.of("openid", "email", "profile");
 
-  public void setAzureControlPlaneEnabled(Boolean azureControlPlaneEnabled) {
-    this.azureControlPlaneEnabled = azureControlPlaneEnabled;
-  }
-
-  public Boolean getAzureControlPlaneEnabled() {
-    return azureControlPlaneEnabled;
-  }
-
-  public String getBasePath() {
+    public String getBasePath() {
     return basePath;
   }
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -114,7 +114,7 @@ profile:
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
 
     application-offers:
-      - name: terra-dev-preview
+      - name: terra-prod
         publisher: thebroadinstituteinc1615909626976
         authorized-user-key: authorizedTerraUser
 


### PR DESCRIPTION
- use the existing policy feature flag: azure-control-plane-enabled: true/false
- when feature flag is enabled, the api/azure/v1/managedApps endpoint returns managed apps deployed from an Azure ServiceCatalog instead of the typical Marketplace deployed managed apps