### PR TITLE
[TOAZ-343]: api/azure/v1/managedApps support for ServiceCatalog deployed azure managed apps

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
@@ -12,6 +12,7 @@ public record AzureConfiguration(
     String managedAppClientId,
     String managedAppClientSecret,
     String managedAppTenantId,
+    Boolean controlPlaneEnabled,
     Set<AzureApplicationOffer> applicationOffers,
     Set<String> requiredProviders) {
   private static final Logger logger = LoggerFactory.getLogger(AzureConfiguration.class);
@@ -85,5 +86,9 @@ public record AzureConfiguration(
 
   public Set<String> getRequiredProviders() {
     return requiredProviders;
+  }
+
+  public Boolean getControlPlaneEnabled() {
+    return controlPlaneEnabled;
   }
 }

--- a/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
@@ -9,6 +9,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +22,7 @@ public class PolicyServiceConfiguration {
 
   private String basePath;
   private String clientCredentialFilePath;
-  private Boolean azureControlPlaneEnabled;
+  private final AzureConfiguration azureConfiguration;
 
   private static final List<String> POLICY_SERVICE_ACCOUNT_SCOPES =
       List.of("openid", "email", "profile");
@@ -42,16 +43,13 @@ public class PolicyServiceConfiguration {
     return clientCredentialFilePath;
   }
 
-  public void setAzureControlPlaneEnabled(Boolean azureControlPlaneEnabled) {
-    this.azureControlPlaneEnabled = azureControlPlaneEnabled;
-  }
-
-  public Boolean getAzureControlPlaneEnabled() {
-    return azureControlPlaneEnabled;
+  @Autowired
+  PolicyServiceConfiguration(AzureConfiguration azureConfiguration) {
+    this.azureConfiguration = azureConfiguration;
   }
 
   public String getAccessToken() throws IOException {
-    if (azureControlPlaneEnabled) {
+    if (azureConfiguration.controlPlaneEnabled()) {
       TokenCredential credential = new DefaultAzureCredentialBuilder().build();
       // The Microsoft Authentication Library (MSAL) currently specifies offline_access, openid,
       // profile, and email by default in authorization and token requests.

--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -7,7 +7,6 @@ import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.model.AzureManagedAppsResponseModel;
 import bio.terra.profile.service.azure.AzureService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -35,9 +34,8 @@ public class AzureApiController implements AzureApi {
   public ResponseEntity<AzureManagedAppsResponseModel> getManagedAppDeployments(
       UUID azureSubscriptionId, Boolean includeAssignedApplications) {
     final AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
-    List<AzureManagedAppModel> managedApps;
 
-    managedApps =
+    var managedApps =
         this.azureService.getAuthorizedManagedAppDeployments(
             azureSubscriptionId, includeAssignedApplications, userRequest);
 

--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -3,9 +3,12 @@ package bio.terra.profile.app.controller;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.profile.api.AzureApi;
+import bio.terra.profile.app.configuration.PolicyServiceConfiguration;
+import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.model.AzureManagedAppsResponseModel;
 import bio.terra.profile.service.azure.AzureService;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -18,24 +21,38 @@ public class AzureApiController implements AzureApi {
   private final HttpServletRequest request;
   private final AzureService azureService;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  private final PolicyServiceConfiguration policyServiceConfiguration;
 
   @Autowired
   public AzureApiController(
       HttpServletRequest request,
       AzureService azureService,
-      AuthenticatedUserRequestFactory authenticatedUserRequestFactory) {
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
+      PolicyServiceConfiguration policyServiceConfiguration) {
     this.request = request;
     this.azureService = azureService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
+    this.policyServiceConfiguration = policyServiceConfiguration;
   }
 
   @Override
   public ResponseEntity<AzureManagedAppsResponseModel> getManagedAppDeployments(
       UUID azureSubscriptionId, Boolean includeAssignedApplications) {
     final AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
-    var managedApps =
-        this.azureService.getAuthorizedManagedAppDeployments(
-            azureSubscriptionId, includeAssignedApplications, userRequest);
+    List<AzureManagedAppModel> managedApps;
+
+    // check azure control plane feature flag
+    if (this.policyServiceConfiguration.getAzureControlPlaneEnabled()) {
+      // get ServiceCatalog deployed managed apps
+      managedApps =
+          this.azureService.getServiceCatalogManagedAppDeployments(
+              azureSubscriptionId, includeAssignedApplications, userRequest);
+    } else {
+      // get Marketplace deployed managed apps
+      managedApps =
+          this.azureService.getAuthorizedManagedAppDeployments(
+              azureSubscriptionId, includeAssignedApplications, userRequest);
+    }
 
     return new ResponseEntity<>(
         new AzureManagedAppsResponseModel().managedApps(managedApps), HttpStatus.OK);

--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -3,7 +3,6 @@ package bio.terra.profile.app.controller;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.profile.api.AzureApi;
-import bio.terra.profile.app.configuration.PolicyServiceConfiguration;
 import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.model.AzureManagedAppsResponseModel;
 import bio.terra.profile.service.azure.AzureService;
@@ -21,18 +20,15 @@ public class AzureApiController implements AzureApi {
   private final HttpServletRequest request;
   private final AzureService azureService;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
-  private final PolicyServiceConfiguration policyServiceConfiguration;
 
   @Autowired
   public AzureApiController(
       HttpServletRequest request,
       AzureService azureService,
-      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
-      PolicyServiceConfiguration policyServiceConfiguration) {
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory) {
     this.request = request;
     this.azureService = azureService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
-    this.policyServiceConfiguration = policyServiceConfiguration;
   }
 
   @Override
@@ -41,18 +37,9 @@ public class AzureApiController implements AzureApi {
     final AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
     List<AzureManagedAppModel> managedApps;
 
-    // check azure control plane feature flag
-    if (this.policyServiceConfiguration.getAzureControlPlaneEnabled()) {
-      // get ServiceCatalog deployed managed apps
-      managedApps =
-          this.azureService.getServiceCatalogManagedAppDeployments(
-              azureSubscriptionId, includeAssignedApplications, userRequest);
-    } else {
-      // get Marketplace deployed managed apps
-      managedApps =
-          this.azureService.getAuthorizedManagedAppDeployments(
-              azureSubscriptionId, includeAssignedApplications, userRequest);
-    }
+    managedApps =
+        this.azureService.getAuthorizedManagedAppDeployments(
+            azureSubscriptionId, includeAssignedApplications, userRequest);
 
     return new ResponseEntity<>(
         new AzureManagedAppsResponseModel().managedApps(managedApps), HttpStatus.OK);

--- a/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/AzureApiController.java
@@ -3,7 +3,6 @@ package bio.terra.profile.app.controller;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.profile.api.AzureApi;
-import bio.terra.profile.model.AzureManagedAppModel;
 import bio.terra.profile.model.AzureManagedAppsResponseModel;
 import bio.terra.profile.service.azure.AzureService;
 import jakarta.servlet.http.HttpServletRequest;

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -88,7 +88,6 @@ profile:
   policy:
     client-credential-file-path: build/resources/main/generated/bpm-client-sa.json
     base-path: ${env.tps.basePath}
-    azure-control-plane-enabled: false
 
   stairway-database:
     password: ${env.db.stairway.pass}
@@ -112,6 +111,7 @@ profile:
     managed-app-clientId: ${env.azure.managedAppClientId}
     managed-app-client-secret: ${env.azure.managedAppClientSecret}
     managed-app-tenant-id: ${env.azure.managedAppTenantId}
+    control-plane-enabled: false
 
     application-offers:
       - name: terra-dev-preview

--- a/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/azure/AzureServiceUnitTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.app.configuration.AzureConfiguration;
+import bio.terra.profile.app.configuration.PolicyServiceConfiguration;
 import bio.terra.profile.common.BaseUnitTest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.AzureManagedAppModel;
@@ -50,6 +51,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
   String offerPublisher = "known_terra_publisher";
   String authorizedUserKey = "authorizedTerraUser";
   String regionName = "application-region";
+  String marketPlaceAppKind = "Marketplace";
+  String serviceCatalogAppKind = "ServiceCatalog";
 
   private ApplicationManager mockApplicationManager(List<Application> apps) {
     var appsIter = mock(PagedIterable.class);
@@ -79,7 +82,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
       String offerPublisher,
       Optional<String> authedUserEmail,
       String managedResourceGroupId,
-      String applicationName) {
+      String applicationName,
+      String kind) {
     var application = mock(Application.class);
     when(application.plan())
         .thenReturn(new Plan().withProduct(offerName).withPublisher(offerPublisher));
@@ -95,6 +99,7 @@ class AzureServiceUnitTest extends BaseUnitTest {
     when(application.managedResourceGroupId()).thenReturn(managedResourceGroupId);
     when(application.name()).thenReturn(applicationName);
     when(application.regionName()).thenReturn(regionName);
+    when(application.kind()).thenReturn(kind);
     return application;
   }
 
@@ -102,22 +107,51 @@ class AzureServiceUnitTest extends BaseUnitTest {
   void getManagedApps() {
     var authedTerraApp =
         mockApplicationCalls(
-            offerName, offerPublisher, Optional.of(authedUserEmail), "mrg_fake1", "fake_app_1");
+            offerName,
+            offerPublisher,
+            Optional.of(authedUserEmail),
+            "mrg_fake1",
+            "fake_app_1",
+            marketPlaceAppKind);
 
     var unauthedTerraApp =
         mockApplicationCalls(
-            offerName, offerPublisher, Optional.empty(), "mrg_fake2", "fake_app_2");
+            offerName,
+            offerPublisher,
+            Optional.empty(),
+            "mrg_fake2",
+            "fake_app_2",
+            marketPlaceAppKind);
 
     var otherNonTerraApp =
         mockApplicationCalls(
-            "other_offer", offerPublisher, Optional.empty(), "mrg_fake3", "fake_app3");
+            "other_offer",
+            offerPublisher,
+            Optional.empty(),
+            "mrg_fake3",
+            "fake_app3",
+            marketPlaceAppKind);
 
     var differentPublisherApp =
         mockApplicationCalls(
-            offerName, "other_publisher", Optional.of(authedUserEmail), "mrg_fake1", "fake_app_1");
+            offerName,
+            "other_publisher",
+            Optional.of(authedUserEmail),
+            "mrg_fake1",
+            "fake_app_1",
+            marketPlaceAppKind);
+
+    var serviceCatalogTerraApp =
+        mockApplicationCalls(
+            "", "", Optional.of(authedUserEmail), "mrg_fake4", "fake_app_4", serviceCatalogAppKind);
 
     var appsList =
-        List.of(authedTerraApp, unauthedTerraApp, otherNonTerraApp, differentPublisherApp);
+        List.of(
+            authedTerraApp,
+            unauthedTerraApp,
+            otherNonTerraApp,
+            differentPublisherApp,
+            serviceCatalogTerraApp);
 
     var crlService = mock(AzureCrlService.class);
     var appManager = mockApplicationManager(appsList);
@@ -126,6 +160,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
     when(crlService.getResourceManager(subId)).thenReturn(resourceManager);
 
     var profileDao = mock(ProfileDao.class);
+    var policyServiceConfiguration = mock(PolicyServiceConfiguration.class);
+    when(policyServiceConfiguration.getAzureControlPlaneEnabled()).thenReturn(false);
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
     offer.setName(offerName);
@@ -139,7 +175,6 @@ class AzureServiceUnitTest extends BaseUnitTest {
             profileDao);
 
     var result = azureService.getAuthorizedManagedAppDeployments(subId, true, user);
-
     var expected =
         List.of(
             new AzureManagedAppModel()
@@ -153,13 +188,60 @@ class AzureServiceUnitTest extends BaseUnitTest {
   }
 
   @Test
+  void getServiceCatalogManagedApps() {
+    var serviceCatalogTerraApp =
+        mockApplicationCalls(
+            "", "", Optional.of(authedUserEmail), "mrg_fake4", "fake_app_4", serviceCatalogAppKind);
+
+    var appsList = List.of(serviceCatalogTerraApp);
+
+    var crlService = mock(AzureCrlService.class);
+    var appManager = mockApplicationManager(appsList);
+    when(crlService.getApplicationManager(subId)).thenReturn(appManager);
+    var resourceManager = mockResourceManager(subId, tenantId);
+    when(crlService.getResourceManager(subId)).thenReturn(resourceManager);
+
+    var profileDao = mock(ProfileDao.class);
+    var policyServiceConfiguration = mock(PolicyServiceConfiguration.class);
+    when(policyServiceConfiguration.getAzureControlPlaneEnabled()).thenReturn(true);
+
+    var offer = new AzureConfiguration.AzureApplicationOffer();
+    offer.setName(offerName);
+    offer.setPublisher(offerPublisher);
+    offer.setAuthorizedUserKey(authorizedUserKey);
+    var offers = Set.of(offer);
+    var azureService =
+        new AzureService(
+            crlService,
+            new AzureConfiguration("fake", "fake", "fake", offers, ImmutableSet.of()),
+            profileDao);
+
+    var result = azureService.getServiceCatalogManagedAppDeployments(subId, true, user);
+    var expected =
+        List.of(
+            new AzureManagedAppModel()
+                .applicationDeploymentName("fake_app_4")
+                .tenantId(tenantId)
+                .managedResourceGroupId("mrg_fake4")
+                .subscriptionId(subId)
+                .assigned(false)
+                .region(regionName));
+    assertEquals(result, expected);
+  }
+
+  @Test
   void getManagedApps_dedupesApps() {
     var crlService = mock(AzureCrlService.class);
     var profileDao = mock(ProfileDao.class);
 
     var authedTerraApp =
         mockApplicationCalls(
-            offerName, offerPublisher, Optional.of(authedUserEmail), "mrg_fake1", "fake_app_1");
+            offerName,
+            offerPublisher,
+            Optional.of(authedUserEmail),
+            "mrg_fake1",
+            "fake_app_1",
+            marketPlaceAppKind);
 
     var appsList = List.of(authedTerraApp, authedTerraApp);
 
@@ -200,7 +282,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
             offerPublisher,
             Optional.of(authedUserEmail),
             assignedTerraAppManagedResourceGroupId,
-            applicationName);
+            applicationName,
+            marketPlaceAppKind);
 
     var unassignedTerraApp =
         mockApplicationCalls(
@@ -208,7 +291,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
             offerPublisher,
             Optional.of(authedUserEmail),
             unassignedTerraAppManagedResourceGroupId,
-            applicationName);
+            applicationName,
+            marketPlaceAppKind);
 
     var offer = new AzureConfiguration.AzureApplicationOffer();
     offer.setName(offerName);
@@ -267,7 +351,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
             offerPublisher,
             Optional.of(authedUserEmail),
             assignedTerraAppManagedResourceGroupId,
-            applicationName);
+            applicationName,
+            marketPlaceAppKind);
 
     var unassignedTerraApp =
         mockApplicationCalls(
@@ -275,7 +360,8 @@ class AzureServiceUnitTest extends BaseUnitTest {
             offerPublisher,
             Optional.of(authedUserEmail),
             unassignedTerraAppManagedResourceGroupId,
-            applicationName);
+            applicationName,
+            marketPlaceAppKind);
 
     var appsList = List.of(assignedTerraApp, unassignedTerraApp);
     var crlService = mock(AzureCrlService.class);
@@ -328,7 +414,12 @@ class AzureServiceUnitTest extends BaseUnitTest {
   void getManagedApps_handlesDifferentEmailFormats(String authorizedEmails) {
     var authedTerraApp =
         mockApplicationCalls(
-            offerName, offerPublisher, Optional.of(authorizedEmails), "mrg_fake1", "fake_app_1");
+            offerName,
+            offerPublisher,
+            Optional.of(authorizedEmails),
+            "mrg_fake1",
+            "fake_app_1",
+            marketPlaceAppKind);
 
     var appsList = List.of(authedTerraApp);
     var crlService = mock(AzureCrlService.class);

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStepTest.java
@@ -60,7 +60,7 @@ class CreateProfileVerifyDeployedApplicationStepTest extends BaseSpringUnitTest 
             "creator");
     var azureConfiguration =
         new AzureConfiguration(
-            "fake_client", "fake_secret", "fake_tenant", ImmutableSet.of(), providers);
+            "fake_client", "fake_secret", "fake_tenant", false, ImmutableSet.of(), providers);
     when(azureService.getRegisteredProviderNamespacesForSubscription(
             profile.getRequiredTenantId(), profile.getRequiredSubscriptionId()))
         .thenReturn(providers);


### PR DESCRIPTION
- Uses the azure-control-plane-enabled feature flag to switch between finding Marketplace/ServiceCatalog deployed apps
- For ServiceCatlog deployed apps, we don't use the publisher or plan AMA properties, instead we are looking at the kind (''ServiceCatalog") and matching up the authuser email
- New test for ServiceCatalog app kind