### PR TITLE
[WOR-1562] Use Google access token for Google calls

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	implementation 'org.springframework:spring-aspects'
 	implementation group: "org.apache.commons", name: "commons-lang3"
 	implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
-
+	implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.18'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 

--- a/service/src/main/java/bio/terra/profile/service/crl/GcpCrlService.java
+++ b/service/src/main/java/bio/terra/profile/service/crl/GcpCrlService.java
@@ -6,7 +6,9 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.service.crl.exception.CrlInternalException;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.nimbusds.jwt.SignedJWT;
 import java.io.IOException;
+import java.text.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Component;
 public class GcpCrlService {
 
   private final ClientConfig clientConfig;
+  private static final String GOOGLE_ACCESS_TOKEN_CLAIM = "idp_access_token";
 
   @Autowired
   public GcpCrlService(ClientConfig clientConfig) {
@@ -24,7 +27,8 @@ public class GcpCrlService {
   /** Returns a GCP {@link CloudBillingClientCow} which wraps Google Billing API. */
   public CloudBillingClientCow getBillingClientCow(AuthenticatedUserRequest user) {
     try {
-      return new CloudBillingClientCow(clientConfig, getUserCredentials(user.getToken()));
+      return new CloudBillingClientCow(
+          clientConfig, getUserCredentials(getGoogleAccessToken(user.getToken())));
     } catch (IOException e) {
       throw new CrlInternalException("Error creating billing client wrapper", e);
     }
@@ -32,5 +36,15 @@ public class GcpCrlService {
 
   private GoogleCredentials getUserCredentials(String token) {
     return GoogleCredentials.newBuilder().setAccessToken(new AccessToken(token, null)).build();
+  }
+
+  private String getGoogleAccessToken(String userToken) {
+    try {
+      var jwt = SignedJWT.parse(userToken);
+      return (String) jwt.getJWTClaimsSet().getClaim(GOOGLE_ACCESS_TOKEN_CLAIM);
+    } catch (ParseException e) {
+      // even if the token is not a valid JWT, it may still be a valid Google access token
+      return userToken;
+    }
   }
 }


### PR DESCRIPTION
Ticket: [WOR-1562](https://broadworkbench.atlassian.net/browse/WOR-1562)
* We need to use a Google access token to for Google API calls. The token in the `AuthenticatedUserRequest` can be either a B2C JWT or a Google access token. If the token is a B2C JWT, it will have the user's Google access token included as a `idp_access_token` claim which we need to use for Google API calls. If the token isn't a JWT, we assume it's a valid Google access token and attempt to use it anyways.

[WOR-1562]: https://broadworkbench.atlassian.net/browse/WOR-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ