### PR TITLE
[WOR-1448] Upgrade TCL 1.1.4 -> 1.1.6

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:7.6.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.4-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.6-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'


### PR DESCRIPTION
This versions transitive dependency on k8s client at 20.0.1 (was 20.0.1-legacy) including KubePodListener fixes to work with the non-legacy client.

Related TCL PR: https://github.com/DataBiosphere/terra-common-lib/pull/174