### PR TITLE
[WOR-1632] Make azure auth token scope configurable.

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/AzureConfiguration.java
@@ -13,6 +13,7 @@ public record AzureConfiguration(
     String managedAppClientSecret,
     String managedAppTenantId,
     Boolean controlPlaneEnabled,
+    String authTokenScope,
     Set<AzureApplicationOffer> applicationOffers,
     Set<String> requiredProviders) {
   private static final Logger logger = LoggerFactory.getLogger(AzureConfiguration.class);

--- a/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
@@ -55,7 +55,7 @@ public class PolicyServiceConfiguration {
       // profile, and email by default in authorization and token requests.
       com.azure.core.credential.AccessToken token =
           credential
-              .getToken(new TokenRequestContext().addScopes("https://graph.microsoft.com/.default"))
+              .getToken(new TokenRequestContext().addScopes("661e243c-5ef9-4a9c-9be3-b7f5585828b3/.default"))
               .block();
       return token.getToken();
     } else {

--- a/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/PolicyServiceConfiguration.java
@@ -55,7 +55,7 @@ public class PolicyServiceConfiguration {
       // profile, and email by default in authorization and token requests.
       com.azure.core.credential.AccessToken token =
           credential
-              .getToken(new TokenRequestContext().addScopes("661e243c-5ef9-4a9c-9be3-b7f5585828b3/.default"))
+              .getToken(new TokenRequestContext().addScopes(azureConfiguration.authTokenScope()))
               .block();
       return token.getToken();
     } else {


### PR DESCRIPTION
On integration testing we found that the proxy couldn’t verify the signature of the managed identity token with scope of [graph.microsoft.com/.default](http://graph.microsoft.com/.default). This makes the scope configurable so we can set it correctly to the [client_id]/.default and change it in the future if needed for any reason with a PR.