### PR TITLE
[WOR-1652] Bump TCL to pull in bouncy-castle fix

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:7.8.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.6-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.11-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'


### PR DESCRIPTION
Pulling in the latest TCL to bump bouncy-castle to fix a CVE.

[Source clear run on main illustrating the presence of the CVE for bouncy-castle](https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/runs/9080538162/job/24952229115)
[Clean source clear run against this branch](https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/runs/9080620910/job/24952527896
)