### PR TITLE
[AJ-1835] Add limits to BPM profile/organization

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -1,8 +1,27 @@
 package bio.terra.profile.app.configuration;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 @ConfigurationProperties(prefix = "profile.limits")
-public record LimitsConfiguration(Map<UUID, Map<String, String>> subscriptions) {}
+public class LimitsConfiguration {
+    private Map<UUID, Map<String, String>> profiles;
+
+    public Map<UUID, Map<String, String>> getProfiles() {
+        return profiles;
+    }
+
+    public void setProfiles(Map<UUID, Map<String, String>> profiles) {
+        this.profiles = profiles;
+    }
+
+    public Map<String, String> getLimitsForProfile(UUID profileId){
+        return this.profiles.getOrDefault(profileId, Collections.emptyMap());
+    }
+}
+
+

--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -2,7 +2,8 @@ package bio.terra.profile.app.configuration;
 
 import java.util.Map;
 import java.util.UUID;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "profile.limits")
-public record LimitsConfiguration(Map<UUID, Map<String, String>> limits) {}
+public record LimitsConfiguration(Map<UUID, Map<String, String>> subscriptions) {}

--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -1,11 +1,8 @@
 package bio.terra.profile.app.configuration;
 
+import java.util.Map;
+import java.util.UUID;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
 @ConfigurationProperties(prefix = "profile.limits")
-public record LimitsConfiguration(Map<UUID, Map<String,String>> limits) {
-}
+public record LimitsConfiguration(Map<UUID, Map<String, String>> limits) {}

--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -2,7 +2,6 @@ package bio.terra.profile.app.configuration;
 
 import java.util.Map;
 import java.util.UUID;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "profile.limits")

--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -1,0 +1,11 @@
+package bio.terra.profile.app.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@ConfigurationProperties(prefix = "profile.limits")
+public record LimitsConfiguration(Map<UUID, Map<String,String>> limits) {
+}

--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -4,24 +4,21 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+/** Describes what limits should be placed on resources for the given billing profile */
 @ConfigurationProperties(prefix = "profile.limits")
 public class LimitsConfiguration {
-    private Map<UUID, Map<String, String>> profiles;
+  private Map<UUID, Map<String, String>> profiles;
 
-    public Map<UUID, Map<String, String>> getProfiles() {
-        return profiles;
-    }
+  public Map<UUID, Map<String, String>> getProfiles() {
+    return profiles;
+  }
 
-    public void setProfiles(Map<UUID, Map<String, String>> profiles) {
-        this.profiles = profiles;
-    }
+  public void setProfiles(Map<UUID, Map<String, String>> profiles) {
+    this.profiles = profiles;
+  }
 
-    public Map<String, String> getLimitsForProfile(UUID profileId){
-        return this.profiles.getOrDefault(profileId, Collections.emptyMap());
-    }
+  public Map<String, String> getLimitsForProfile(UUID profileId) {
+    return this.profiles.getOrDefault(profileId, Collections.emptyMap());
+  }
 }
-
-

--- a/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/LimitsConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /** Describes what limits should be placed on resources for the given billing profile */
 @ConfigurationProperties(prefix = "profile.limits")
 public class LimitsConfiguration {
-  private Map<UUID, Map<String, String>> profiles;
+  private Map<UUID, Map<String, String>> profiles = Collections.emptyMap();
 
   public Map<UUID, Map<String, String>> getProfiles() {
     return profiles;

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -8,6 +8,7 @@ import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.profile.app.common.MetricUtils;
 import bio.terra.profile.app.configuration.EnterpriseConfiguration;
+import bio.terra.profile.app.configuration.LimitsConfiguration;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.model.Organization;
 import bio.terra.profile.model.SamPolicyModel;
@@ -48,21 +49,24 @@ public class ProfileService {
   private final TpsApiDispatch tpsApiDispatch;
   private final EnterpriseConfiguration enterpriseConfiguration;
   private final GcpService gcpService;
+  private final LimitsConfiguration limitsConfiguration;
 
   @Autowired
   public ProfileService(
-      ProfileDao profileDao,
-      SamService samService,
-      JobService jobService,
-      TpsApiDispatch tpsApiDispatch,
-      GcpService gcpService,
-      EnterpriseConfiguration enterpriseConfiguration) {
+          ProfileDao profileDao,
+          SamService samService,
+          JobService jobService,
+          TpsApiDispatch tpsApiDispatch,
+          GcpService gcpService,
+          EnterpriseConfiguration enterpriseConfiguration,
+          LimitsConfiguration limitsConfiguration) {
     this.profileDao = profileDao;
     this.samService = samService;
     this.jobService = jobService;
     this.tpsApiDispatch = tpsApiDispatch;
     this.enterpriseConfiguration = enterpriseConfiguration;
     this.gcpService = gcpService;
+    this.limitsConfiguration = limitsConfiguration;
   }
 
   /**
@@ -233,7 +237,8 @@ public class ProfileService {
             profile
                 .subscriptionId()
                 .map(enterpriseConfiguration.subscriptions()::contains)
-                .orElse(false));
+                .orElse(false))
+            .limits(profile.subscriptionId().map(limitsConfiguration.limits()::get).orElse(null));
   }
 
   private ProfileDescription profileDescription(BillingProfile profile) {

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -29,6 +29,7 @@ import bio.terra.profile.service.profile.flight.delete.DeleteProfileFlight;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.profile.service.profile.model.ProfileDescription;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -238,7 +239,9 @@ public class ProfileService {
                 .subscriptionId()
                 .map(enterpriseConfiguration.subscriptions()::contains)
                 .orElse(false))
-        .limits(profile.subscriptionId().map(limitsConfiguration.limits()::get).orElse(null));
+        .limits(profile.subscriptionId().map(
+                id -> limitsConfiguration.subscriptions().get(id)
+        ).orElse(Map.of()));
   }
 
   private ProfileDescription profileDescription(BillingProfile profile) {

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -239,10 +239,13 @@ public class ProfileService {
                 .subscriptionId()
                 .map(enterpriseConfiguration.subscriptions()::contains)
                 .orElse(false))
-        .limits(profile.subscriptionId().flatMap(
-                        id -> Optional.ofNullable(limitsConfiguration.subscriptions())
-                                .map(subscriptions -> subscriptions.get(id))
-                )
+        .limits(
+            profile
+                .subscriptionId()
+                .flatMap(
+                    id ->
+                        Optional.ofNullable(limitsConfiguration.subscriptions())
+                            .map(subscriptions -> subscriptions.get(id)))
                 .orElse(Map.of()));
   }
 

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -239,9 +239,11 @@ public class ProfileService {
                 .subscriptionId()
                 .map(enterpriseConfiguration.subscriptions()::contains)
                 .orElse(false))
-        .limits(profile.subscriptionId().map(
-                id -> limitsConfiguration.subscriptions().get(id)
-        ).orElse(Map.of()));
+        .limits(profile.subscriptionId().flatMap(
+                        id -> Optional.ofNullable(limitsConfiguration.subscriptions())
+                                .map(subscriptions -> subscriptions.get(id))
+                )
+                .orElse(Map.of()));
   }
 
   private ProfileDescription profileDescription(BillingProfile profile) {

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -53,13 +53,13 @@ public class ProfileService {
 
   @Autowired
   public ProfileService(
-          ProfileDao profileDao,
-          SamService samService,
-          JobService jobService,
-          TpsApiDispatch tpsApiDispatch,
-          GcpService gcpService,
-          EnterpriseConfiguration enterpriseConfiguration,
-          LimitsConfiguration limitsConfiguration) {
+      ProfileDao profileDao,
+      SamService samService,
+      JobService jobService,
+      TpsApiDispatch tpsApiDispatch,
+      GcpService gcpService,
+      EnterpriseConfiguration enterpriseConfiguration,
+      LimitsConfiguration limitsConfiguration) {
     this.profileDao = profileDao;
     this.samService = samService;
     this.jobService = jobService;
@@ -238,7 +238,7 @@ public class ProfileService {
                 .subscriptionId()
                 .map(enterpriseConfiguration.subscriptions()::contains)
                 .orElse(false))
-            .limits(profile.subscriptionId().map(limitsConfiguration.limits()::get).orElse(null));
+        .limits(profile.subscriptionId().map(limitsConfiguration.limits()::get).orElse(null));
   }
 
   private ProfileDescription profileDescription(BillingProfile profile) {

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -28,10 +28,7 @@ import bio.terra.profile.service.profile.flight.create.CreateProfileFlight;
 import bio.terra.profile.service.profile.flight.delete.DeleteProfileFlight;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.profile.service.profile.model.ProfileDescription;
-
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -28,6 +28,8 @@ import bio.terra.profile.service.profile.flight.create.CreateProfileFlight;
 import bio.terra.profile.service.profile.flight.delete.DeleteProfileFlight;
 import bio.terra.profile.service.profile.model.BillingProfile;
 import bio.terra.profile.service.profile.model.ProfileDescription;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -239,14 +241,7 @@ public class ProfileService {
                 .subscriptionId()
                 .map(enterpriseConfiguration.subscriptions()::contains)
                 .orElse(false))
-        .limits(
-            profile
-                .subscriptionId()
-                .flatMap(
-                    id ->
-                        Optional.ofNullable(limitsConfiguration.subscriptions())
-                            .map(subscriptions -> subscriptions.get(id)))
-                .orElse(Map.of()));
+        .limits(limitsConfiguration.getLimitsForProfile(profile.id()));
   }
 
   private ProfileDescription profileDescription(BillingProfile profile) {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -704,6 +704,11 @@ components:
         enterprise:
           description: whether this is an enterprise organization i.e. they have a signed BAA
           type: boolean
+        limits:
+          description: compute or other limits imposed on workspaces in this organization
+          type: object
+          additionalProperties:
+            type: string
 
     SpendReport:
       type: object

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -142,6 +142,8 @@ profile:
   enterprise:
     subscriptions:
 
+  limits:
+
 terra.common:
   kubernetes:
     in-kubernetes: false

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -247,15 +247,14 @@ class ProfileServiceUnitTest extends BaseUnitTest {
     var organizationSubscription = UUID.randomUUID();
     var limitedProfile =
         ProfileFixtures.createAzureBillingProfile(
-                UUID.randomUUID(), organizationSubscription, "limitedMRG");
+            UUID.randomUUID(), organizationSubscription, "limitedMRG");
     var nonLimitedProfile =
         ProfileFixtures.createAzureBillingProfile(
-                UUID.randomUUID(), organizationSubscription, "nonLimitedMRG");
+            UUID.randomUUID(), organizationSubscription, "nonLimitedMRG");
     Map<String, String> limitMap = Map.of("vcpus", "4");
-    when(limitsConfiguration.getLimitsForProfile(limitedProfile.id()))
-            .thenReturn(limitMap);
+    when(limitsConfiguration.getLimitsForProfile(limitedProfile.id())).thenReturn(limitMap);
     when(limitsConfiguration.getLimitsForProfile(nonLimitedProfile.id()))
-            .thenReturn(Collections.emptyMap());
+        .thenReturn(Collections.emptyMap());
 
     when(profileDao.getBillingProfileById(limitedProfile.id())).thenReturn(limitedProfile);
     when(profileDao.getBillingProfileById(nonLimitedProfile.id())).thenReturn(nonLimitedProfile);

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -100,7 +100,7 @@ class ProfileServiceUnitTest extends BaseUnitTest {
             tpsApiDispatch,
             gcpService,
             enterpriseConfiguration,
-                limitsConfiguration);
+            limitsConfiguration);
     user =
         AuthenticatedUserRequest.builder()
             .setSubjectId("12345")
@@ -243,15 +243,14 @@ class ProfileServiceUnitTest extends BaseUnitTest {
     Map<String, String> limitMap = Map.of("vcpus", "4");
     when(limitsConfiguration.limits()).thenReturn(Map.of(organizationSubscription, limitMap));
     var limitedProfile =
-            ProfileFixtures.createAzureBillingProfile(
-                    UUID.randomUUID(), organizationSubscription, "limitedMRG");
+        ProfileFixtures.createAzureBillingProfile(
+            UUID.randomUUID(), organizationSubscription, "limitedMRG");
     var nonLimitedProfile =
-            ProfileFixtures.createAzureBillingProfile(
-                    UUID.randomUUID(), UUID.randomUUID(), "nonLimitedMRG");
+        ProfileFixtures.createAzureBillingProfile(
+            UUID.randomUUID(), UUID.randomUUID(), "nonLimitedMRG");
 
     when(profileDao.getBillingProfileById(limitedProfile.id())).thenReturn(limitedProfile);
-    when(profileDao.getBillingProfileById(nonLimitedProfile.id()))
-            .thenReturn(nonLimitedProfile);
+    when(profileDao.getBillingProfileById(nonLimitedProfile.id())).thenReturn(nonLimitedProfile);
     when(samService.hasActions(eq(user), eq(SamResourceType.PROFILE), any())).thenReturn(true);
     when(tpsApiDispatch.getOrCreatePao(any(), any(), any())).thenReturn(new TpsPaoGetResult());
 

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -123,7 +123,9 @@ class ProfileServiceUnitTest extends BaseUnitTest {
             "creator");
     profileDescription =
         new ProfileDescription(
-            profile, Optional.empty(), Optional.of(new Organization().enterprise(false)));
+            profile,
+            Optional.empty(),
+            Optional.of(new Organization().enterprise(false).limits(Map.of())));
 
     userPolicy = new SamPolicyModel().name("user").members(List.of("user@unit.com"));
     ownerPolicy = new SamPolicyModel().name("owner").members(List.of("owner@unit.com"));
@@ -209,7 +211,9 @@ class ProfileServiceUnitTest extends BaseUnitTest {
     var result = profileService.getProfile(profile.id(), user);
     assertEquals(
         new ProfileDescription(
-            profile, Optional.of(policies), Optional.of(new Organization().enterprise(false))),
+            profile,
+            Optional.of(policies),
+            Optional.of(new Organization().enterprise(false).limits(Map.of()))),
         result);
   }
 
@@ -324,11 +328,11 @@ class ProfileServiceUnitTest extends BaseUnitTest {
             new ProfileDescription(
                 protectedProfile,
                 Optional.of(policies),
-                Optional.of(new Organization().enterprise(false))),
+                Optional.of(new Organization().enterprise(false).limits(Map.of()))),
             new ProfileDescription(
                 enterpriseProfile,
                 Optional.empty(),
-                Optional.of(new Organization().enterprise(true)))));
+                Optional.of(new Organization().enterprise(true).limits(Map.of())))));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -241,7 +241,7 @@ class ProfileServiceUnitTest extends BaseUnitTest {
   void getProfileWithOrganizationLimits() throws InterruptedException {
     var organizationSubscription = UUID.randomUUID();
     Map<String, String> limitMap = Map.of("vcpus", "4");
-    when(limitsConfiguration.limits()).thenReturn(Map.of(organizationSubscription, limitMap));
+    when(limitsConfiguration.subscriptions()).thenReturn(Map.of(organizationSubscription, limitMap));
     var limitedProfile =
         ProfileFixtures.createAzureBillingProfile(
             UUID.randomUUID(), organizationSubscription, "limitedMRG");
@@ -263,7 +263,9 @@ class ProfileServiceUnitTest extends BaseUnitTest {
     assertTrue(limitsMap.containsKey("vcpus"));
 
     Object nonlimitedObject = nonLimitedResult.organization().get().getLimits();
-    assertNull(nonlimitedObject);
+    assertTrue(nonlimitedObject instanceof Map);
+    Map<String, String> emptyMap = (Map<String, String>) nonlimitedObject;
+    assert(emptyMap.isEmpty());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -241,7 +241,8 @@ class ProfileServiceUnitTest extends BaseUnitTest {
   void getProfileWithOrganizationLimits() throws InterruptedException {
     var organizationSubscription = UUID.randomUUID();
     Map<String, String> limitMap = Map.of("vcpus", "4");
-    when(limitsConfiguration.subscriptions()).thenReturn(Map.of(organizationSubscription, limitMap));
+    when(limitsConfiguration.subscriptions())
+        .thenReturn(Map.of(organizationSubscription, limitMap));
     var limitedProfile =
         ProfileFixtures.createAzureBillingProfile(
             UUID.randomUUID(), organizationSubscription, "limitedMRG");
@@ -265,7 +266,7 @@ class ProfileServiceUnitTest extends BaseUnitTest {
     Object nonlimitedObject = nonLimitedResult.organization().get().getLimits();
     assertTrue(nonlimitedObject instanceof Map);
     Map<String, String> emptyMap = (Map<String, String>) nonlimitedObject;
-    assert(emptyMap.isEmpty());
+    assert (emptyMap.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1835
Adds the "limits" map to a billing profile's organization.  This will be used to identify which billing profiles have limits imposed, e.g. for Anvil Lite.  Verified in my BEE that Rawls can still communicate with BPM without needing to update its model (although we will want to do that).

Example of what the config would look like here: https://github.com/broadinstitute/terra-helmfile/pull/5564