### PR TITLE
WOR-1769 add state for missing billing profile pact test

### DIFF
--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -172,6 +172,12 @@ public class BPMProviderTest {
         "managedResourceGroupId", profile.managedResourceGroupId().get());
   }
 
+  @State("a missing billing profile")
+  void missingBillingProfileState() throws InterruptedException {
+    when(samService.hasActions(any(), eq(SamResourceType.PROFILE), any()))
+        .thenReturn(false);
+  }
+
   @State("two billing profiles exist")
   void twoProfilesExistState() throws InterruptedException {
     var profilesIds =

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -116,10 +116,7 @@ public class BPMProviderTest {
     // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
     // tag (e.g. dev, alpha).
     if (StringUtils.isBlank(CONSUMER_BRANCH)) {
-      return new SelectorBuilder()
-          .mainBranch()
-          .deployedOrReleased()
-          .branch("missing_profile_state");
+      return new SelectorBuilder().mainBranch().deployedOrReleased();
     } else {
       return new SelectorBuilder().branch(CONSUMER_BRANCH);
     }

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -116,7 +116,7 @@ public class BPMProviderTest {
     // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
     // tag (e.g. dev, alpha).
     if (StringUtils.isBlank(CONSUMER_BRANCH)) {
-      return new SelectorBuilder().mainBranch().deployedOrReleased();
+      return new SelectorBuilder().mainBranch().deployedOrReleased().branch("missing_profile_state");
     } else {
       return new SelectorBuilder().branch(CONSUMER_BRANCH);
     }

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -116,7 +116,10 @@ public class BPMProviderTest {
     // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
     // tag (e.g. dev, alpha).
     if (StringUtils.isBlank(CONSUMER_BRANCH)) {
-      return new SelectorBuilder().mainBranch().deployedOrReleased().branch("missing_profile_state");
+      return new SelectorBuilder()
+          .mainBranch()
+          .deployedOrReleased()
+          .branch("missing_profile_state");
     } else {
       return new SelectorBuilder().branch(CONSUMER_BRANCH);
     }
@@ -174,8 +177,7 @@ public class BPMProviderTest {
 
   @State("a missing billing profile")
   void missingBillingProfileState() throws InterruptedException {
-    when(samService.hasActions(any(), eq(SamResourceType.PROFILE), any()))
-        .thenReturn(false);
+    when(samService.hasActions(any(), eq(SamResourceType.PROFILE), any())).thenReturn(false);
   }
 
   @State("two billing profiles exist")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1769

need to add a new state to the pact tests so that I have something to update when permission checking changes in https://github.com/DataBiosphere/terra-billing-profile-manager/pull/464

[see this test run](https://github.com/DataBiosphere/terra-billing-profile-manager/actions/runs/9940778571/job/27458338812#step:8:476) for proof that this new state works with [the test in the WSM PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/1774).