### PR TITLE
[WOR-1706] Add leaveProfile endpoint

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
+++ b/service/src/main/java/bio/terra/profile/app/controller/ProfileApiController.java
@@ -82,6 +82,13 @@ public class ProfileApiController implements ProfileApi {
   }
 
   @Override
+  public ResponseEntity<Void> leaveProfile(UUID id) {
+    AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
+    profileService.leaveProfile(id, user);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @Override
   public ResponseEntity<SamPolicyModelList> getProfilePolicies(UUID id) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     List<SamPolicyModel> policies = profileService.getProfilePolicies(id, user);

--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -253,7 +253,7 @@ public class SamService {
     try {
       SamRetry.retry(() -> leaveResourceInner(userRequest, samResourceTypeName, resourceId));
     } catch (ApiException e) {
-      throw SamExceptionFactory.create("Error deleting profile member in Sam", e);
+      throw SamExceptionFactory.create("Error leaving resource in Sam", e);
     }
   }
 

--- a/service/src/main/java/bio/terra/profile/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/profile/service/iam/SamService.java
@@ -240,6 +240,31 @@ public class SamService {
   }
 
   /**
+   * Removes the authenticated user from the specified resource.
+   *
+   * @param userRequest authenticated user
+   * @param samResourceTypeName the type of resource being left
+   * @param resourceId resourceId of the profile in question
+   * @throws InterruptedException
+   */
+  public void leaveResource(
+      AuthenticatedUserRequest userRequest, String samResourceTypeName, UUID resourceId)
+      throws InterruptedException {
+    try {
+      SamRetry.retry(() -> leaveResourceInner(userRequest, samResourceTypeName, resourceId));
+    } catch (ApiException e) {
+      throw SamExceptionFactory.create("Error deleting profile member in Sam", e);
+    }
+  }
+
+  private void leaveResourceInner(
+      AuthenticatedUserRequest userRequest, String samResourceTypeName, UUID resourceId)
+      throws ApiException {
+    ResourcesApi samResourceApi = samResourcesApi(userRequest.getToken());
+    samResourceApi.leaveResourceV2(samResourceTypeName, resourceId.toString());
+  }
+
+  /**
    * Fetch the user status (email and subjectId) from Sam.
    *
    * @param userToken user token

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -237,7 +237,7 @@ public class ProfileService {
 
   public SamPolicyModel deleteProfilePolicyMember(
       UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
-    if (user.getEmail().equals(memberEmail)) {
+    if (memberEmail.equals(user.getEmail())) {
       throw new InvalidFieldException(
           "Use leaveProfile to remove the current user from a billing profile.");
     }

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -21,6 +21,7 @@ import bio.terra.profile.service.job.JobMapKeys;
 import bio.terra.profile.service.job.JobService;
 import bio.terra.profile.service.policy.TpsApiDispatch;
 import bio.terra.profile.service.policy.exception.PolicyServiceAPIException;
+import bio.terra.profile.service.profile.exception.InvalidFieldException;
 import bio.terra.profile.service.profile.exception.ProfileNotFoundException;
 import bio.terra.profile.service.profile.flight.ProfileMapKeys;
 import bio.terra.profile.service.profile.flight.create.CreateProfileFlight;
@@ -236,6 +237,10 @@ public class ProfileService {
 
   public SamPolicyModel deleteProfilePolicyMember(
       UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+    if (user.getEmail().equals(memberEmail)) {
+      throw new InvalidFieldException(
+          "Use leaveProfile to remove the current user from a billing profile.");
+    }
     return SamRethrow.onInterrupted(
         () -> samService.deleteProfilePolicyMember(user, profileId, policyName, memberEmail),
         "deletePolicyMember");

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -210,6 +210,18 @@ public class ProfileService {
     profileDao.removeBillingAccount(id);
   }
 
+  /**
+   * Removes the authenticated user from the specified billing profile.
+   *
+   * @param profileId profile to leave
+   * @param user authenticated user
+   */
+  public void leaveProfile(UUID profileId, AuthenticatedUserRequest user) {
+    String spendProfileTypeName = SamResourceType.PROFILE.getSamResourceName();
+    SamRethrow.onInterrupted(
+        () -> samService.leaveResource(user, spendProfileTypeName, profileId), "leaveProfile");
+  }
+
   public List<SamPolicyModel> getProfilePolicies(UUID profileId, AuthenticatedUserRequest user) {
     return SamRethrow.onInterrupted(
         () -> samService.retrieveProfilePolicies(user, profileId), "retrieveProfilePolicies");

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -170,6 +170,27 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/profiles/v1/{profileId}/leave:
+    delete:
+      tags:
+        - Profile
+      description: >
+        Removes the authenticated user from the specified profile.
+      operationId: leaveProfile
+      parameters:
+        - $ref: '#/components/parameters/ProfileId'
+      responses:
+        '204':
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/profiles/v1/{profileId}/spendReport:
     parameters:
       - $ref: '#/components/parameters/ProfileId'

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -243,6 +243,13 @@ public class BPMProviderTest {
         .thenReturn(jobBuilder);
   }
 
+  @State("a Sam service that supports leaving resources")
+  void leaveResourceExistsState() throws InterruptedException {
+    var resourceType = SamResourceType.PROFILE.getSamResourceName();
+    var profile = ProviderStateData.azureBillingProfile;
+    doNothing().when(samService).leaveResource(any(), eq(resourceType), eq(profile.id()));
+  }
+
   @State("a Sam service that supports profile policy member addition")
   Map<String, Object> userPolicyAdditionState() throws InterruptedException {
     var profile = ProviderStateData.azureBillingProfile;

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -547,6 +547,13 @@ class ProfileServiceUnitTest extends BaseUnitTest {
   }
 
   @Test
+  void leaveProfile() throws InterruptedException {
+    assertDoesNotThrow(() -> profileService.leaveProfile(profile.id(), user));
+    verify(samService)
+        .leaveResource(user, SamResourceType.PROFILE.getSamResourceName(), profile.id());
+  }
+
+  @Test
   void getProfilePolicies() throws InterruptedException {
     when(samService.retrieveProfilePolicies(user, profile.id())).thenReturn(profilePolicies);
     var result = profileService.getProfilePolicies(profile.id(), user);

--- a/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/ProfileServiceUnitTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.google.billing.CloudBillingClientCow;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -609,6 +610,14 @@ class ProfileServiceUnitTest extends BaseUnitTest {
     var result =
         profileService.deleteProfilePolicyMember(profile.id(), "owner", "leaving@unit.com", user);
     assertEquals(ownerPolicy, result);
+  }
+
+  @Test
+  void deleteProfilePolicyMember400() throws InterruptedException {
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            profileService.deleteProfilePolicyMember(profile.id(), "user", user.getEmail(), user));
   }
 
   @Test


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/WOR-1706](https://broadworkbench.atlassian.net/browse/WOR-1706)

Adds support for Sam `leaveResource` to be used in BPM. Then use that to create a new BPM endpoint, `leaveProfile`, which removes the authenticated user from a billing profile.

Updated unit tests and contract testing between Rawls and BPM.