### PR TITLE
update to use dsp-reusable-workflows, also no vault

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -211,7 +211,7 @@ jobs:
 
       - name: Publish contracts
         id: publish-contracts
-        uses: broadinstitute/dsp-reusable-workflows/.github/actions/run-publish-contracts@DDO-3840-move-publish-contracts
+        uses: broadinstitute/dsp-reusable-workflows/.github/actions/run-publish-contracts@main
         with:
           PACT_B64: ${{ steps.encode-pact.outputs.pact-b64 }}
           REPO_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -209,22 +209,18 @@ jobs:
           nonBreakingB64=$(cat "${{ matrix.pact_path }}" | base64 -w 0)
           echo "pact-b64=${nonBreakingB64}" >> $GITHUB_OUTPUT  
 
-      - name: Dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v4.0.0
+      - name: Publish contracts
+        id: publish-contracts
+        uses: broadinstitute/dsp-reusable-workflows/.github/actions/run-publish-contracts@DDO-3840-move-publish-contracts
         with:
-          run-name: "${{ env.PUBLISH_CONTRACTS_RUN_NAME }}-${{ matrix.pact_path }}"
-          workflow: .github/workflows/publish-contracts.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{
-            "run-name": "${{ env.PUBLISH_CONTRACTS_RUN_NAME }}-${{ matrix.pact_path }}",
-            "pact-b64": "${{ steps.encode-pact.outputs.pact-b64 }}",
-            "repo-owner": "${{ github.repository_owner }}",
-            "repo-name": "${{ github.event.repository.name }}",
-            "repo-branch": "${{ needs.init-github-context.outputs.repo-branch }}",
-            "release-tag": "${{ needs.regulated-tag-job.outputs.new-tag }}"
-            }'
+          PACT_B64: ${{ needs.encode-pact.outputs.pact-b64 }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_BRANCH: ${{ needs.init-github-context.outputs.repo-branch }}
+          BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          RELEASE_TAG: ${{ needs.regulated-tag-job.outputs.new-tag }}
 
   ###############################        
   # PROVIDER VERIFICATION STEPS #

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -213,7 +213,7 @@ jobs:
         id: publish-contracts
         uses: broadinstitute/dsp-reusable-workflows/.github/actions/run-publish-contracts@DDO-3840-move-publish-contracts
         with:
-          PACT_B64: ${{ needs.encode-pact.outputs.pact-b64 }}
+          PACT_B64: ${{ steps.encode-pact.outputs.pact-b64 }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           REPO_BRANCH: ${{ needs.init-github-context.outputs.repo-branch }}


### PR DESCRIPTION
updates this workflow to use a new version in dsp-resuable-workflow, gets rid of the workflow-dispatch + vault calls, so should 
1) give better visibility / simplifly flow
2) deprecates vault usage