### PR TITLE
WOR-1805 Update BillingProfile.createdBy to Use User ID

### DIFF
--- a/service/src/main/java/bio/terra/profile/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/profile/db/ProfileDao.java
@@ -2,7 +2,6 @@ package bio.terra.profile.db;
 
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
-import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.profile.exception.DuplicateManagedApplicationException;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
@@ -54,8 +53,7 @@ public class ProfileDao {
   }
 
   @WriteTransaction
-  public BillingProfile createBillingProfile(
-      BillingProfile profile, AuthenticatedUserRequest user) {
+  public BillingProfile createBillingProfile(BillingProfile profile, String initiatingUser) {
     String sql =
         "INSERT INTO billing_profile"
             + " (id, display_name, biller, billing_account_id, description, cloud_platform, "
@@ -79,7 +77,7 @@ public class ProfileDao {
             .addValue("tenant_id", tenantId)
             .addValue("subscription_id", subscriptionId)
             .addValue("managed_resource_group_id", managedResourceGroupId)
-            .addValue("created_by", user.getEmail());
+            .addValue("created_by", initiatingUser);
 
     var keyHolder = new DaoKeyHolder();
     try {

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlight.java
@@ -37,8 +37,10 @@ public class CreateProfileFlight extends Flight {
     AuthenticatedUserRequest user =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
+    var initiatingUser = inputParameters.get(JobMapKeys.INITIATING_USER.getKeyName(), String.class);
+
     addStep(new GetProfileStep(profileDao, billingProfile));
-    addStep(new CreateProfileStep(profileDao, billingProfile, user));
+    addStep(new CreateProfileStep(profileDao, billingProfile, initiatingUser));
     switch (billingProfile.cloudPlatform()) {
       case GCP:
         addStep(
@@ -58,7 +60,7 @@ public class CreateProfileFlight extends Flight {
       // we can link the profile to the MRG only after the Sam resource has been created
       addStep(new LinkBillingProfileIdToMrgStep(samService, billingProfile, user));
     }
-    var initiatingUser = inputParameters.get(JobMapKeys.INITIATING_USER.getKeyName(), String.class);
+
     addStep(new RecordProfileCreationStep(changeLogDao, initiatingUser));
     addStep(new CreateProfileFinishStep());
   }

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileStep.java
@@ -1,6 +1,5 @@
 package bio.terra.profile.service.profile.flight.create;
 
-import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.profile.db.ProfileDao;
 import bio.terra.profile.service.profile.flight.ProfileMapKeys;
 import bio.terra.profile.service.profile.model.BillingProfile;
@@ -12,13 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Step to create a billing profile in the database. */
-record CreateProfileStep(
-    ProfileDao profileDao, BillingProfile profile, AuthenticatedUserRequest user) implements Step {
+record CreateProfileStep(ProfileDao profileDao, BillingProfile profile, String initiatingUser)
+    implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateProfileStep.class);
 
   @Override
   public StepResult doStep(FlightContext flightContext) {
-    var createdProfile = profileDao.createBillingProfile(profile, user);
+    var createdProfile = profileDao.createBillingProfile(profile, initiatingUser);
     logger.info("Profile created with id {}", createdProfile.id());
 
     FlightMap workingMap = flightContext.getWorkingMap();

--- a/service/src/test/java/bio/terra/profile/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/profile/db/ProfileDaoTest.java
@@ -53,7 +53,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void createAndGetProfile() {
     var profile = makeGCPProfile();
-    var createResult = profileDao.createBillingProfile(profile, user);
+    var createResult = profileDao.createBillingProfile(profile, user.getSubjectId());
     assertProfileEquals(profile, createResult);
     var getResult = profileDao.getBillingProfileById(profile.id());
     assertProfileEquals(profile, getResult);
@@ -62,9 +62,11 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void createProfile_alreadyExists() {
     var profile = makeGCPProfile();
-    var createResult = profileDao.createBillingProfile(profile, user);
+    var createResult = profileDao.createBillingProfile(profile, user.getSubjectId());
     assertProfileEquals(profile, createResult);
-    assertThrows(DuplicateKeyException.class, () -> profileDao.createBillingProfile(profile, user));
+    assertThrows(
+        DuplicateKeyException.class,
+        () -> profileDao.createBillingProfile(profile, user.getSubjectId()));
   }
 
   @Test
@@ -77,7 +79,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
     profileIds.add(profileId);
     var profile = makeAzureProfile(tenantId, subscriptionId, managedResourceGroupId);
 
-    var createResult = profileDao.createBillingProfile(profile, user);
+    var createResult = profileDao.createBillingProfile(profile, user.getSubjectId());
     assertProfileEquals(profile, createResult);
 
     UUID duplicatedProfileId = UUID.randomUUID();
@@ -99,21 +101,25 @@ class ProfileDaoTest extends BaseSpringUnitTest {
 
     assertThrows(
         DuplicateManagedApplicationException.class,
-        () -> profileDao.createBillingProfile(duplicatedManagedAppCoordsProfile, user));
+        () ->
+            profileDao.createBillingProfile(
+                duplicatedManagedAppCoordsProfile, user.getSubjectId()));
 
     var differentMRGProfile =
         makeAzureProfile(tenantId, subscriptionId, "new_managed_resource_group");
-    assertDoesNotThrow(() -> profileDao.createBillingProfile(differentMRGProfile, user));
+    assertDoesNotThrow(
+        () -> profileDao.createBillingProfile(differentMRGProfile, user.getSubjectId()));
 
     var differentSubscriptionProfile =
         makeAzureProfile(tenantId, UUID.randomUUID(), managedResourceGroupId);
-    assertDoesNotThrow(() -> profileDao.createBillingProfile(differentSubscriptionProfile, user));
+    assertDoesNotThrow(
+        () -> profileDao.createBillingProfile(differentSubscriptionProfile, user.getSubjectId()));
   }
 
   @Test
   void createAndDeleteProfile() {
     var profile = makeGCPProfile();
-    var createResult = profileDao.createBillingProfile(profile, user);
+    var createResult = profileDao.createBillingProfile(profile, user.getSubjectId());
     assertProfileEquals(profile, createResult);
     var deleteResult = profileDao.deleteBillingProfileById(profile.id());
     assertTrue(deleteResult);
@@ -124,7 +130,8 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void listProfiles() {
     var profiles =
-        Stream.generate(() -> profileDao.createBillingProfile(makeGCPProfile(), user))
+        Stream.generate(
+                () -> profileDao.createBillingProfile(makeGCPProfile(), user.getSubjectId()))
             .limit(10)
             .collect(Collectors.toList());
     var keys = profiles.stream().map(BillingProfile::id).collect(Collectors.toList());
@@ -135,7 +142,8 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void listProfiles_subset() {
     var profiles =
-        Stream.generate(() -> profileDao.createBillingProfile(makeGCPProfile(), user))
+        Stream.generate(
+                () -> profileDao.createBillingProfile(makeGCPProfile(), user.getSubjectId()))
             .limit(10)
             .collect(Collectors.toList());
     var keys = profiles.stream().limit(3).map(BillingProfile::id).collect(Collectors.toList());
@@ -146,7 +154,8 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void listProfiles_offset() {
     var profiles =
-        Stream.generate(() -> profileDao.createBillingProfile(makeGCPProfile(), user))
+        Stream.generate(
+                () -> profileDao.createBillingProfile(makeGCPProfile(), user.getSubjectId()))
             .limit(10)
             .collect(Collectors.toList());
     var keys = profiles.stream().map(BillingProfile::id).collect(Collectors.toList());
@@ -157,7 +166,8 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void listProfiles_limit() {
     var profiles =
-        Stream.generate(() -> profileDao.createBillingProfile(makeGCPProfile(), user))
+        Stream.generate(
+                () -> profileDao.createBillingProfile(makeGCPProfile(), user.getSubjectId()))
             .limit(10)
             .collect(Collectors.toList());
     var keys = profiles.stream().map(BillingProfile::id).collect(Collectors.toList());
@@ -173,11 +183,11 @@ class ProfileDaoTest extends BaseSpringUnitTest {
     String differentSubscriptionMRGId = "differentSubscriptionMRGId";
 
     var profile = makeAzureProfile(tenantId, subscriptionId, managedResourceGroupId);
-    profileDao.createBillingProfile(profile, user);
+    profileDao.createBillingProfile(profile, user.getSubjectId());
 
     var differentSubscriptionProfile =
         makeAzureProfile(tenantId, UUID.randomUUID(), differentSubscriptionMRGId);
-    profileDao.createBillingProfile(differentSubscriptionProfile, user);
+    profileDao.createBillingProfile(differentSubscriptionProfile, user.getSubjectId());
 
     var result = profileDao.listManagedResourceGroupsInSubscription(subscriptionId);
     assertEquals(List.of(managedResourceGroupId), result);
@@ -186,7 +196,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void updateProfile_descriptionOnly() {
     var profile = makeGCPProfile();
-    profileDao.createBillingProfile(profile, user);
+    profileDao.createBillingProfile(profile, user.getSubjectId());
 
     assert profileDao.updateProfile(profile.id(), "new description", null);
     var result = profileDao.getBillingProfileById(profile.id());
@@ -197,7 +207,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void updateProfile_billingAccountOnly() {
     var profile = makeGCPProfile();
-    profileDao.createBillingProfile(profile, user);
+    profileDao.createBillingProfile(profile, user.getSubjectId());
 
     assert profileDao.updateProfile(profile.id(), null, "newBillingAccountId");
     var result = profileDao.getBillingProfileById(profile.id());
@@ -208,7 +218,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void updateProfile_descriptionAndBillingAccount() {
     var profile = makeGCPProfile();
-    profileDao.createBillingProfile(profile, user);
+    profileDao.createBillingProfile(profile, user.getSubjectId());
 
     assert profileDao.updateProfile(profile.id(), "new description", "newBillingAccountId");
     var result = profileDao.getBillingProfileById(profile.id());
@@ -219,7 +229,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void updateProfile_throwNoFields() {
     var profile = makeGCPProfile();
-    profileDao.createBillingProfile(profile, user);
+    profileDao.createBillingProfile(profile, user.getSubjectId());
 
     assertThrows(
         MissingRequiredFieldsException.class,
@@ -238,7 +248,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
   @Test
   void removeBillingAccount() {
     var profile = makeGCPProfile();
-    profileDao.createBillingProfile(profile, user);
+    profileDao.createBillingProfile(profile, user.getSubjectId());
     assert profileDao.removeBillingAccount(profile.id());
     assertEquals(
         Optional.empty(), profileDao.getBillingProfileById(profile.id()).billingAccountId());
@@ -295,7 +305,7 @@ class ProfileDaoTest extends BaseSpringUnitTest {
     assertEquals(expected.managedResourceGroupId(), actual.managedResourceGroupId());
     assertNotNull(actual.createdTime());
     assertNotNull(actual.lastModified());
-    assertEquals(user.getEmail(), actual.createdBy());
+    assertEquals(user.getSubjectId(), actual.createdBy());
   }
 
   private void assertProfileListEquals(List<BillingProfile> expected, List<BillingProfile> actual) {

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -81,7 +81,7 @@ class CreateProfileFlightTest extends BaseSpringUnitTest {
     assertEquals(createdProfile.displayName(), profile.displayName());
     assertNotNull(createdProfile.createdTime());
     assertNotNull(createdProfile.lastModified());
-    assertEquals(createdProfile.createdBy(), userRequest.getEmail());
+    assertEquals(createdProfile.createdBy(), userRequest.getSubjectId());
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1805

## Description
This PR changes the BillingProfile.createdBy field to store the user's ID (user.getSubjectId()) instead of their email. It also updates the logic to use initiatingUser when specified, ensuring consistent behavior with the changelog.

### Changes:

- BillingProfile.createdBy: Now stores the user's ID instead of their email.
- initiatingUser: Now used when specified, matching the changelog behavior.

### Testing:

- Updated tests to ensure correct storage of user IDs and proper handling of initiatingUser.