### PR TITLE
Revert "Revert "[WOR-864] Check SA account access to verify Terra billing permissions""

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/GcpConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/GcpConfiguration.java
@@ -1,0 +1,29 @@
+package bio.terra.profile.app.configuration;
+
+import com.google.api.services.compute.ComputeScopes;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "profile.gcp")
+public class GcpConfiguration {
+  private String saCredentialFilePath;
+
+  public void setSaCredentialFilePath(String clientCredentialFilePath) {
+    this.saCredentialFilePath = clientCredentialFilePath;
+  }
+
+  public String getSaCredentialFilePath() {
+    return saCredentialFilePath;
+  }
+
+  public GoogleCredentials getSaCredentials() throws IOException {
+    try (FileInputStream fileInputStream = new FileInputStream(saCredentialFilePath)) {
+      // need this broad scope to create/manage projects (same one that is used in Rawls)
+      final String manageProjectScope = ComputeScopes.CLOUD_PLATFORM;
+      return ServiceAccountCredentials.fromStream(fileInputStream).createScoped(manageProjectScope);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/profile/service/crl/GcpCrlService.java
+++ b/service/src/main/java/bio/terra/profile/service/crl/GcpCrlService.java
@@ -26,8 +26,13 @@ public class GcpCrlService {
 
   /** Returns a GCP {@link CloudBillingClientCow} which wraps Google Billing API. */
   public CloudBillingClientCow getBillingClientCow(AuthenticatedUserRequest user) {
+    return getBillingClientCow(getUserCredentials(user.getToken()));
+  }
+
+  /** Returns a GCP {@link CloudBillingClientCow} which wraps Google Billing API. */
+  public CloudBillingClientCow getBillingClientCow(GoogleCredentials credentials) {
     try {
-      return new CloudBillingClientCow(clientConfig, getUserCredentials(user.getToken()));
+      return new CloudBillingClientCow(clientConfig, credentials);
     } catch (IOException e) {
       throw new CrlInternalException("Error creating billing client wrapper", e);
     }

--- a/service/src/main/java/bio/terra/profile/service/gcp/GcpService.java
+++ b/service/src/main/java/bio/terra/profile/service/gcp/GcpService.java
@@ -1,12 +1,15 @@
 package bio.terra.profile.service.gcp;
 
+import bio.terra.cloudres.google.billing.CloudBillingClientCow;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.profile.app.configuration.GcpConfiguration;
 import bio.terra.profile.service.crl.GcpCrlService;
 import bio.terra.profile.service.gcp.exception.InaccessibleBillingAccountException;
 import bio.terra.profile.service.profile.exception.MissingRequiredFieldsException;
 import com.google.cloud.billing.v1.BillingAccountName;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -25,22 +28,42 @@ public class GcpService {
       Collections.singletonList("billing.resourceAssociations.create");
 
   private final GcpCrlService crlService;
+  private final GcpConfiguration configuration;
 
   @Autowired
-  public GcpService(GcpCrlService crlService) {
+  public GcpService(GcpConfiguration configuration, GcpCrlService crlService) {
     this.crlService = crlService;
+    this.configuration = configuration;
+  }
+
+  public void verifyTerraBillingAccountAccess(Optional<String> billingAccountIdOpt) {
+    try {
+      // The BPM SA is a member of the Google group terra-billing@firecloud.org, so we can use it to
+      // verify that we have the necessary permissions to access a billing account.
+      var billingCow = crlService.getBillingClientCow(configuration.getSaCredentials());
+      verifyBillingAccountAccess(billingAccountIdOpt, billingCow, "terra-billing@firecloud.org");
+    } catch (IOException ex) {
+      throw new RuntimeException("Failed to get service account credentials", ex);
+    }
   }
 
   public void verifyUserBillingAccountAccess(
       Optional<String> billingAccountIdOpt, AuthenticatedUserRequest user) {
     var billingCow = crlService.getBillingClientCow(user);
+    verifyBillingAccountAccess(billingAccountIdOpt, billingCow, user.getEmail());
+  }
+
+  public void verifyBillingAccountAccess(
+      Optional<String> billingAccountIdOpt,
+      CloudBillingClientCow billingCow,
+      String userIdentifier) {
     var billingAccountId =
         billingAccountIdOpt.orElseThrow(
             () -> new MissingRequiredFieldsException("Missing billing account ID"));
     logger.info(
         String.format(
             "Checking user %s permissions on billing account %s",
-            user.getEmail(), billingAccountId));
+            userIdentifier, billingAccountId));
 
     var testPermissionsRequest =
         TestIamPermissionsRequest.newBuilder()
@@ -57,7 +80,7 @@ public class GcpService {
       var message =
           String.format(
               "The user [%s] needs access to the billing account [%s] to perform the requested operation",
-              user.getEmail(), billingAccountId);
+              userIdentifier, billingAccountId);
       throw new InaccessibleBillingAccountException(message);
     }
   }

--- a/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/ProfileService.java
@@ -204,6 +204,7 @@ public class ProfileService {
           "verifyBillingAccountUpdateAuthz");
       gcpService.verifyUserBillingAccountAccess(
           Optional.of(requestBody.getBillingAccountId()), user);
+      gcpService.verifyTerraBillingAccountAccess(Optional.of(requestBody.getBillingAccountId()));
     }
 
     var initiatingUser = getInitiatingUserId(user, requestBody.getInitiatingUser());

--- a/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStep.java
+++ b/service/src/main/java/bio/terra/profile/service/profile/flight/create/CreateProfileVerifyAccountStep.java
@@ -18,6 +18,7 @@ public record CreateProfileVerifyAccountStep(
   public StepResult doStep(FlightContext context) throws InterruptedException {
     try {
       gcpService.verifyUserBillingAccountAccess(billingAccountId, user);
+      gcpService.verifyTerraBillingAccountAccess(billingAccountId);
     } catch (InaccessibleBillingAccountException e) {
       throw e;
     } catch (Exception e) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -90,6 +90,9 @@ profile:
     client-credential-file-path: build/resources/main/generated/bpm-client-sa.json
     base-path: ${env.tps.basePath}
 
+  gcp:
+    sa-credential-file-path: build/resources/main/generated/bpm-client-sa.json
+
   stairway-database:
     password: ${env.db.stairway.pass}
     uri: ${env.db.host}/${env.db.stairway.name}

--- a/service/src/test/java/bio/terra/profile/service/gcp/GcpServiceUnitTest.java
+++ b/service/src/test/java/bio/terra/profile/service/gcp/GcpServiceUnitTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.cloudres.google.billing.CloudBillingClientCow;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.profile.app.configuration.GcpConfiguration;
 import bio.terra.profile.common.BaseSpringUnitTest;
 import bio.terra.profile.model.CloudPlatform;
 import bio.terra.profile.service.crl.GcpCrlService;
@@ -55,7 +56,7 @@ public class GcpServiceUnitTest extends BaseSpringUnitTest {
             "creator");
 
     when(crlService.getBillingClientCow(eq(user))).thenReturn(billingClientCow);
-    gcpService = new GcpService(crlService);
+    gcpService = new GcpService(new GcpConfiguration(), crlService);
   }
 
   @Test


### PR DESCRIPTION
Reverts DataBiosphere/terra-billing-profile-manager#482

Reintroduces the changes for WOR-864, which did not work when merged to develop because a necessary the new variable in [application.yml](https://github.com/DataBiosphere/terra-billing-profile-manager/pull/483/files#diff-4dab07009b19ea187f607a407b00997345505227a852e7115e4dcd086f27a388R93) was not present in deployed environments. The needed change to the BPM deployment template is in https://github.com/broadinstitute/terra-helmfile/pull/5868.