### PR TITLE
Add validation query and testOnBorrow to ensure we do not attempt to use invalid connections

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/BaseDatabaseConfiguration.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/BaseDatabaseConfiguration.java
@@ -8,7 +8,6 @@ import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 
 /** Base class for accessing database connection configuration properties. */
@@ -64,10 +63,11 @@ public class BaseDatabaseConfiguration {
 
     PoolableConnectionFactory poolableConnectionFactory =
         new PoolableConnectionFactory(connectionFactory, null);
+    poolableConnectionFactory.setValidationQuery("SELECT 1");
 
-    ObjectPool<PoolableConnection> connectionPool =
+    GenericObjectPool<PoolableConnection> connectionPool =
         new GenericObjectPool<>(poolableConnectionFactory);
-
+    connectionPool.setTestOnBorrow(true);
     poolableConnectionFactory.setPool(connectionPool);
 
     dataSource = new PoolingDataSource<>(connectionPool);


### PR DESCRIPTION
BPM dev tests flaked on 10/4, with the error message "terminating connection due to administrator command". My hypothesis is that is due to Google Cloud SQL maintenance overnight invalidating connections in BPM's pool.

This PR adds a simple validation query and enforces that connections are [tested](https://commons.apache.org/proper/commons-dbcp/configuration.html) at borrow-time before being returned on consumers. 