### PR TITLE
CORE-391: upgrade TCL to 1.1.28

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.6.0'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.3.4'
     implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.6.0'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.3.4'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.1'
     implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
 

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'io.swagger.core.v3:swagger-annotations:2.1.12'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.8.0'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
     implementation 'org.slf4j:slf4j-api'

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'io.swagger.core.v3:swagger-annotations:2.1.12'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.8.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.9.0'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
     implementation 'org.slf4j:slf4j-api'

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
@@ -5,6 +5,3 @@ plugins {
     id 'io.spring.dependency-management'
     id 'org.springframework.boot'
 }
-
-// This version should match the one in terra-common-lib
-// ext['opentelemetry.version'] = '1.42.1'

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
@@ -7,4 +7,4 @@ plugins {
 }
 
 // This version should match the one in terra-common-lib
-ext['opentelemetry.version'] = '1.42.1'
+// ext['opentelemetry.version'] = '1.42.1'

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
@@ -6,6 +6,5 @@ plugins {
     id 'org.springframework.boot'
 }
 
-// Spring Boot 3.2.3 pulls in opentelemetry-bom 1.31.0.
-// It must have version >= 1.34.1 for compatibility with terra-common-lib 1.0.9:
-ext['opentelemetry.version'] = '1.36.0'
+// This version should match the one in terra-common-lib
+ext['opentelemetry.version'] = '1.37.0'

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-spring-conventions.gradle
@@ -7,4 +7,4 @@ plugins {
 }
 
 // This version should match the one in terra-common-lib
-ext['opentelemetry.version'] = '1.37.0'
+ext['opentelemetry.version'] = '1.42.1'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -46,8 +46,10 @@ dependencies {
 	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.269"
 
     // TPS
-    implementation group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT"
-
+    implementation(group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT") {
+		// this conflicts with TCL-provided otel libraries
+		exclude group: 'io.opentelemetry.instrumentation', module: 'opentelemetry-spring-boot'
+	}
 
     // Test deps
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.21-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.28-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.18-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.21-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.21-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.18-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.38-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.21-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.11-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.38-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -180,7 +180,9 @@ spendreporting:
 otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
-
+  instrumentation:
+    common:
+      default-enabled: false
   springboot:
     resource:
       attributes:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -181,36 +181,6 @@ otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
 
-  instrumentation:
-    # this is redundant; it sets the default for all following keys.
-    # see https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation/#common-instrumentation-configuration
-    common:
-      default-enabled: false
-    # these are ok to turn on ...
-    jdbc:
-      enabled: true
-    log4j-appender:
-      enabled: true
-    spring-webmvc:
-      enabled: true
-    kafka:
-      enabled: true
-    mongo:
-      enabled: true
-    r2dbc:
-      enabled: true
-    # these are problematic to turn on ...
-    annotations:
-      enabled: false
-    logback-appender:
-      enabled: false
-    micrometer:
-      enabled: false
-    spring-web:
-      enabled: false
-    spring-webflux:
-      enabled: false
-
   springboot:
     resource:
       attributes:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -180,9 +180,37 @@ spendreporting:
 otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
+
   instrumentation:
+    # this is redundant; it sets the default for all following keys.
+    # see https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation/#common-instrumentation-configuration
     common:
       default-enabled: false
+    # these are ok to turn on ...
+    jdbc:
+      enabled: true
+    log4j-appender:
+      enabled: true
+    spring-webmvc:
+      enabled: true
+    kafka:
+      enabled: true
+    mongo:
+      enabled: true
+    r2dbc:
+      enabled: true
+    # these are problematic to turn on ...
+    annotations:
+      enabled: false
+    logback-appender:
+      enabled: false
+    micrometer:
+      enabled: false
+    spring-web:
+      enabled: false
+    spring-webflux:
+      enabled: false
+
   springboot:
     resource:
       attributes:


### PR DESCRIPTION
TCL 1.1.28 is the minimum upgrade that has the k8s client we need. This TCL upgrade carries a Spring Boot upgrade from 3.2.3 to 3.4.1; upgrading further would carry even more upgrades. I suggest we tackle further upgrades in (a) follow-on PR(s).

In this PR:
* upgrade TCL 1.1.11 -> 1.1.28
* upgrade Spring Boot 3.2.3 -> 3.41
* add an exclude to `terra-policy-client` to avoid otel-related Spring autoconfig conflicts

NOT in this PR, suggest we handle in future PR(s):
- resolve Spring warnings on `@MockBean`/`@SpyBean`
- upgrade TCL and Spring Boot to latest versions