### PR TITLE
CORE-391: MockBean -> MockitoBean

### DIFF
--- a/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/AzureApiControllerTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
@@ -23,8 +23,8 @@ class AzureApiControllerTest extends BaseSpringUnitTest {
 
   @Autowired MockMvc mockMvc;
 
-  @MockBean SamService samService;
-  @MockBean AzureService azureService;
+  @MockitoBean SamService samService;
+  @MockitoBean AzureService azureService;
   private final AuthenticatedUserRequest userRequest =
       AuthenticatedUserRequest.builder()
           .setEmail("example@example.com")

--- a/service/src/test/java/bio/terra/profile/app/controller/SpendReportingApiControllerTest.java
+++ b/service/src/test/java/bio/terra/profile/app/controller/SpendReportingApiControllerTest.java
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
 class SpendReportingApiControllerTest extends BaseSpringUnitTest {
   @Autowired MockMvc mockMvc;
-  @MockBean SamService samService;
-  @MockBean SpendReportingService spendReportingService;
+  @MockitoBean SamService samService;
+  @MockitoBean SpendReportingService spendReportingService;
   @Autowired SpendReportingConfig spendReportingConfig;
 
   private final AuthenticatedUserRequest userRequest = AuthRequestFixtures.buildAuthRequest();

--- a/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
+++ b/service/src/test/java/bio/terra/profile/pact/provider/BPMProviderTest.java
@@ -61,12 +61,12 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.cache.CacheManager;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @Tag("provider-test")
 @Provider("bpm")
@@ -91,26 +91,26 @@ public class BPMProviderTest {
 
   @LocalServerPort int port;
 
-  @MockBean ProfileDao profileDao;
-  @MockBean ProfileChangeLogDao changeLogDao;
-  @MockBean SamService samService;
-  @MockBean TpsApiDispatch tpsApiDispatch;
+  @MockitoBean ProfileDao profileDao;
+  @MockitoBean ProfileChangeLogDao changeLogDao;
+  @MockitoBean SamService samService;
+  @MockitoBean TpsApiDispatch tpsApiDispatch;
 
-  @MockBean AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockitoBean AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   @Mock AuthenticatedUserRequest userRequest;
 
   // These mocks are just here so that spring can instantiate beans for the ApplicationContext
-  @MockBean AzureCrlService azureCrlService;
-  @MockBean GcpCrlService gcpCrlService;
-  @MockBean JobService jobService;
-  @MockBean CacheManager cacheManager;
+  @MockitoBean AzureCrlService azureCrlService;
+  @MockitoBean GcpCrlService gcpCrlService;
+  @MockitoBean JobService jobService;
+  @MockitoBean CacheManager cacheManager;
 
   // jdbcTemplate beans are used for profileStatusService when checking CloudSQL status
-  @MockBean NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-  @MockBean JdbcTemplate jdbcTemplate;
+  @MockitoBean NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @MockitoBean JdbcTemplate jdbcTemplate;
   @Autowired ProfileStatusService profileStatusService;
-  @MockBean AzureSpendReportingService azureSpendReportingService;
-  @MockBean AzureService azureService;
+  @MockitoBean AzureSpendReportingService azureSpendReportingService;
+  @MockitoBean AzureService azureService;
 
   @PactBrokerConsumerVersionSelectors
   public static SelectorBuilder consumerVersionSelectors() {

--- a/service/src/test/java/bio/terra/profile/service/job/JobServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/service/job/JobServiceTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class JobServiceTest extends BaseSpringUnitTest {
   private final AuthenticatedUserRequest testUser =
@@ -36,7 +36,7 @@ class JobServiceTest extends BaseSpringUnitTest {
 
   @Autowired private JobService jobService;
 
-  @MockBean private SamService mockSamService;
+  @MockitoBean private SamService mockSamService;
 
   @BeforeEach
   @SuppressFBWarnings(value = "DE_MIGHT_IGNORE", justification = "Mockito flakiness")

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/create/CreateProfileFlightTest.java
@@ -41,19 +41,19 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class CreateProfileFlightTest extends BaseSpringUnitTest {
 
   @Autowired ProfileService profileService;
   @Autowired AzureConfiguration azureConfiguration;
-  @MockBean GcpCrlService crlService;
-  @MockBean GcpConfiguration gcpConfiguration;
+  @MockitoBean GcpCrlService crlService;
+  @MockitoBean GcpConfiguration gcpConfiguration;
 
-  @MockBean SamService samService;
-  @MockBean AzureService azureService;
-  @MockBean TpsApiDispatch tpsApiDispatch;
-  @MockBean EnterpriseConfiguration enterpriseConfiguration;
+  @MockitoBean SamService samService;
+  @MockitoBean AzureService azureService;
+  @MockitoBean TpsApiDispatch tpsApiDispatch;
+  @MockitoBean EnterpriseConfiguration enterpriseConfiguration;
 
   AuthenticatedUserRequest userRequest =
       AuthenticatedUserRequest.builder()

--- a/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
+++ b/service/src/test/java/bio/terra/profile/service/profile/flight/delete/DeleteProfileFlightTest.java
@@ -25,18 +25,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class DeleteProfileFlightTest extends BaseSpringUnitTest {
 
   @Autowired ProfileService profileService;
   @Autowired AzureConfiguration azureConfiguration;
-  @MockBean GcpCrlService crlService;
+  @MockitoBean GcpCrlService crlService;
 
-  @MockBean ProfileDao profileDao;
-  @MockBean SamService samService;
-  @MockBean AzureService azureService;
-  @MockBean TpsApiDispatch tpsApiDispatch;
+  @MockitoBean ProfileDao profileDao;
+  @MockitoBean SamService samService;
+  @MockitoBean AzureService azureService;
+  @MockitoBean TpsApiDispatch tpsApiDispatch;
 
   AuthenticatedUserRequest userRequest =
       AuthenticatedUserRequest.builder()

--- a/service/src/test/java/bio/terra/profile/service/status/ProfileStatusServiceTest.java
+++ b/service/src/test/java/bio/terra/profile/service/status/ProfileStatusServiceTest.java
@@ -10,12 +10,12 @@ import bio.terra.profile.service.iam.SamService;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class ProfileStatusServiceTest extends BaseSpringUnitTest {
   @Autowired private ProfileStatusService statusService;
 
-  @MockBean private SamService mockSamService;
+  @MockitoBean private SamService mockSamService;
 
   // TODO add more cases when we have something to mock out
 


### PR DESCRIPTION
#531, as part of upgrading terra-common-lib, upgraded Spring Boot.

The newer version of Spring Boot deprecates `@MockBean` in favor of `@MockitoBean` and logs warnings during compilation when `@MockBean` is used.

This PR switches all usages of `@MockBean` to `@MockitoBean`.