### PR TITLE
CORE-391: update to latest TCL

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.6.0'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.7'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.1'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.4.3'
     implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
 

--- a/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.profile.java-common-conventions.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     compileOnly "com.google.code.findbugs:annotations:3.0.1"
     implementation 'io.swagger.core.v3:swagger-annotations:2.1.12'
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.9.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.12.0'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
 
     implementation 'org.slf4j:slf4j-api'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.28-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.38-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -40,10 +40,10 @@ dependencies {
 	implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-costmanagement', version: "1.0.0-beta.7"
 	implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-containerservice', version: '2.48.0'
 
-	implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.7-SNAPSHOT"
+	implementation group: 'bio.terra', name: 'terra-cloud-resource-lib', version: "1.2.34-SNAPSHOT"
 
 	// Sam
-	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.269"
+	implementation group: "org.broadinstitute.dsde.workbench", name: "sam-client_2.13", version: "v0.0.371"
 
     // TPS
     implementation(group: "bio.terra", name:"terra-policy-client", version:"1.0.9-SNAPSHOT") {


### PR DESCRIPTION
#531 upgraded terra-common-lib to 1.1.28, which was the minimum required version to continue working on our live k8s clusters.

This PR upgrades to 1.1.38, which is the latest version. It carries upgrades to a few other dependencies for compatibility.