### PR TITLE
CORE-391: fix swagger-ui re:spring boot upgrade

### DIFF
--- a/service/src/main/java/bio/terra/profile/app/configuration/WebConfig.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/WebConfig.java
@@ -28,8 +28,7 @@ public class WebConfig implements WebMvcConfigurer {
         "\"response_type=token\"",
         "(t.name === \"b2c\" ? \"response_type=id_token&nonce=defaultNonce&prompt=login\" : \"response_type=token\")");
 
-    addOauth2Redirect(
-        registry, "oauth2-redirect.html", "/webjars/swagger-ui-dist/4.5.0");
+    addOauth2Redirect(registry, "oauth2-redirect.html", "/webjars/swagger-ui-dist/4.5.0");
   }
 
   private void addOauth2Redirect(ResourceHandlerRegistry registry, String path, String file) {

--- a/service/src/main/java/bio/terra/profile/app/configuration/WebConfig.java
+++ b/service/src/main/java/bio/terra/profile/app/configuration/WebConfig.java
@@ -24,12 +24,12 @@ public class WebConfig implements WebMvcConfigurer {
     addJsFixers(
         registry,
         "/webjars/swagger-ui-dist/swagger-ui-bundle.js",
-        "/webjars/swagger-ui-dist/4.5.0/swagger-ui-bundle.js",
+        "/webjars/swagger-ui-dist/4.5.0",
         "\"response_type=token\"",
         "(t.name === \"b2c\" ? \"response_type=id_token&nonce=defaultNonce&prompt=login\" : \"response_type=token\")");
 
     addOauth2Redirect(
-        registry, "oauth2-redirect.html", "/webjars/swagger-ui-dist/4.3.0/oauth2-redirect.html");
+        registry, "oauth2-redirect.html", "/webjars/swagger-ui-dist/4.5.0");
   }
 
   private void addOauth2Redirect(ResourceHandlerRegistry registry, String path, String file) {


### PR DESCRIPTION
#531, as part of upgrading terra-common-lib, upgraded Spring Boot.

The Spring Boot upgrade carried a behavior change to `WebMvcConfigurer`. This behavior change caused BPM's swagger-ui to fail because it couldn't find `/webjars/swagger-ui-dist/swagger-ui-bundle.js`.

This PR fixes that!