### PR TITLE
CORE-376: turn off double-tracing and 'failed to export spans' error

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -15,7 +15,7 @@ apply from: 'publishing.gradle'
 dependencies {
 	implementation 'io.sentry:sentry:8.4.0'
 
-	implementation 'bio.terra:terra-common-lib:1.1.38-SNAPSHOT'
+	implementation 'bio.terra:terra-common-lib:1.1.39-SNAPSHOT'
 
 	implementation 'org.apache.commons:commons-dbcp2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -181,11 +181,6 @@ otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
 
-  # terra-common-lib configures trace exporting to GCP; we need to disable the
-  # built-in otel exporter.
-  traces:
-    exporter: none
-
   resource:
     attributes:
       service:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -181,9 +181,13 @@ otel:
   sdk:
     disabled: false # set to true to disable all open telemetry features
 
-  springboot:
-    resource:
-      attributes:
-        service:
-          name: ${spring.application.name}
-          version: ${bpm.version.gitTag:unknown}
+  # terra-common-lib configures trace exporting to GCP; we need to disable the
+  # built-in otel exporter.
+  traces:
+    exporter: none
+
+  resource:
+    attributes:
+      service:
+        name: ${spring.application.name}
+        version: ${bpm.version.gitTag:unknown}


### PR DESCRIPTION
Update TCL to get its fix for the "failed to export spans" error.

See https://github.com/DataBiosphere/terra-common-lib/pull/229

Tested by running locally, seeing no errors logged, and seeing traces reported to GCP.